### PR TITLE
Update pip install command text in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ pip install -e .[openai]
 pip install -e .[gemini]
 
 # For both
-pip install -e .[openai, gemini]
+pip install -e .[openai,gemini]
 
 # For OpenAI and Qdrant
-pip install -e .[openai, qdrant]
+pip install -e .[openai,qdrant]
 
 # For All
 pip install -e .[all]


### PR DESCRIPTION
When I run the pip command of README, it was such error.

```
# pip install -e .[openai, gemini]
ERROR: Invalid requirement: 'gemini]'
```

I remove space after comma, then it works.
```
pip install -e .[openai,gemini]
```