### PR TITLE
Change the interface of vector db module for supporting more function of each client

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Langrila is a useful tool to use API-based LLM in an easy way. This library put 
 ## as needed
 - openai and tiktoken for OpenAI API
 - google-generativeai for Gemini API
-- qdrant-client for retrieval
+- qdrant-client or chromadb for retrieval
 
 # Contribution
 ## Coding policy
@@ -60,6 +60,9 @@ poetry add --editable /path/to/langrila/ --extras "openai gemini"
 # For OpenAI and Qdrant
 poetry add --editable /path/to/langrila/ --extras "openai qdrant"
 
+# For OpenAI and Chroma
+poetry add --editable /path/to/langrila/ --extras "openai chroma"
+
 # For all extra dependencies
 poetry add --editable /path/to/langrila/ --extras all
 ```
@@ -103,12 +106,24 @@ poetry add --editable /path/to/langrila/ --extras all
 - gemini-1.5-flash
 
 # Breaking changes
-#### v0.0.2 -> v0.0.3
+<details>
+<summary>v0.0.7 -> v0.0.8</summary>
+
+Database modules has breaking changes such as rename of method, variable length argument of run/arun method of collection module apply to _upsert method instead of _create_collection method. For details, see change logs.
+
+</details>
+
+
+<details>
+<summary>v0.0.2 -> v0.0.3</summary>
+
 I have integrated gemini api into langrila on v0.0.3. When doing this, the modules for openai and azure openai should be separated from gemini's modules so that unnecessary dependencies won't happen while those components has the same interface. But migration is easy. Basically only thing to do is to change import modules level like `from langrila import OpenAIChatModule` to `from langrila.openai import OpenAIChatModule`. It's the same as other modules related to openai api.
 
 Second change point is return type of `stream()` and `astream()` method. From v0.0.3, all return types of all chunks is CompletionResults.
 
-Third point is the name of results class : `RetrievalResult` to `RetrievalResults`
+Third point is the name of results class : `RetrievalResult` to `RetrievalResults`. `RetrievalResults` model has collections atribute now. Also similarities was replaced with scores.
+
+</details>
 
 # Basic usage
 ## Basic example
@@ -530,56 +545,128 @@ Now only Qdrant are supported for basic retrieval.
 
 ### For Qdrant
 ```python
-from langrila.openai import OpenAIEmbeddingModule
+from qdrant_client import models
+
 from langrila.database.qdrant import QdrantLocalCollectionModule, QdrantLocalRetrievalModule
+from langrila.openai import OpenAIEmbeddingModule
 
 #######################
 # create collection
 #######################
 
 embedder = OpenAIEmbeddingModule(
-        api_key_env_name="API_KEY", 
-    )
+    api_key_env_name="API_KEY",
+    model_name="text-embedding-3-small",
+    dimensions=1536,
+)
 
 collection = QdrantLocalCollectionModule(
-    persistence_directory="qdrant", 
-    collection_name="sample", 
-    embedder=embedder
+    persistence_directory="./qdrant_test",
+    collection_name="sample",
+    embedder=embedder,
+    vectors_config=models.VectorParams(
+        size=1536,
+        distance=models.Distance.COSINE,
+    ),
 )
 
 documents = [
     "Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.",
-    "LangChain is a framework for developing applications powered by language models.", 
-    "LlamaIndex (GPT Index) is a data framework for your LLM application."
+    "LangChain is a framework for developing applications powered by language models.",
+    "LlamaIndex (GPT Index) is a data framework for your LLM application.",
 ]
 
-# Collection limits the number of its records (<= 10000 records) to keep memory error away.
+# Collection limits the number of its records (default <= 10000 records) to keep memory error away.
 # If you can include records over limitation, collection will be automatically divided into multiple collection.
-collection(documents=documents)
+collection.run(documents=documents) # metadatas could also be used
 
-#######################
-# retrieval
-#######################
+# #######################
+# # retrieval
+# #######################
 
 # In the case collection was already instantiated
 # retriever = collection.as_retriever(n_results=2, threshold_similarity=0.8)
 
 retriever = QdrantLocalRetrievalModule(
-            embedder=embedder,
-            persistence_directory="qdrant", 
-            collection_name="sample", 
-            n_results=2,
-            threshold_similarity=0.8,
-        )
+    embedder=embedder,
+    persistence_directory="./qdrant_test",
+    collection_name="sample",
+    n_results=2,
+    score_threshold=0.5,
+)
 
 # If multiple collections are available, search all collections and merge each results later, then return top-k results.
 query = "What is Langrila?"
-retriever(query, filter=None).model_dump()
+retriever.run(query, filter=None).model_dump()
+>>> {'ids': [0],
+ 'documents': ['Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'],
+ 'metadatas': [{'collection': 'sample_0',
+   'document': 'Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'}],
+ 'scores': [0.5303465176248179],
+ 'collections': ['sample_0'],
+ 'usage': {'prompt_tokens': 6, 'completion_tokens': 0}}
+```
+
+Qdrant server is also supported by `QdrantRemoteCollectionModule` and `QdrantRemoteRetrievalModule`. For more details, see [qdrant.py](src/langrila/database/qdrant.py).
+
+### For Chroma
+```python
+from langrila.database.chroma import ChromaLocalCollectionModule, ChromaLocalRetrievalModule
+from langrila.openai import OpenAIEmbeddingModule
+
+#######################
+# create collection
+#######################
+
+embedder = OpenAIEmbeddingModule(
+    api_key_env_name="API_KEY",
+    model_name="text-embedding-3-small",
+    dimensions=1536,
+)
+
+collection = ChromaLocalCollectionModule(
+    persistence_directory="./chroma_test",
+    collection_name="sample",
+    embedder=embedder,
+)
+
+collection.delete_collection()
+
+documents = [
+    "Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.",
+    "LangChain is a framework for developing applications powered by language models.",
+    "LlamaIndex (GPT Index) is a data framework for your LLM application.",
+]
+
+# Collection limits the number of its records (default <= 10000 records) to keep memory error away.
+# If you can include records over limitation, collection will be automatically divided into multiple collection.
+collection.run(documents=documents) # metadatas could also be used
+
+# #######################
+# # retrieval
+# #######################
+
+# In the case collection was already instantiated
+# retriever = collection.as_retriever(n_results=2, threshold_similarity=0.8)
+
+retriever = ChromaLocalRetrievalModule(
+    embedder=embedder,
+    persistence_directory="./chroma_test",
+    collection_name="sample",
+    n_results=2,
+    score_threshold=0.5,
+)
+
+# If multiple collections are available, search all collections and merge each results later, then return top-k results.
+query = "What is Langrila?"
+retriever.run(query, filter=None).model_dump()
 
 >>> {'ids': [0],
  'documents': ['Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'],
- 'metadatas': [None],
- 'similarities': [0.8371831512206701],
+ 'metadatas': [{'collection': 'sample_0',
+   'document': 'Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'}],
+ 'scores': [0.46960276455443584],
+ 'collections': ['sample_0'],
  'usage': {'prompt_tokens': 6, 'completion_tokens': 0}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ poetry add --editable /path/to/langrila/ --extras all
 <details>
 <summary>v0.0.7 -> v0.0.8</summary>
 
-Database modules has breaking changes from v0.0.7 to v0.0.8 such as rename of method, variable length argument of run/arun method in collection module apply to _upsert method instead of _create_collection method. For details, see change logs.
+Database modules has breaking changes from v0.0.7 to v0.0.8 such as rename of method, change the interface of some methods. For more details, see [this PR](https://github.com/taikinman/langrila/pull/34).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ retriever = QdrantLocalRetrievalModule(
 # If multiple collections are available, search all collections and merge each results later, then return top-k results.
 query = "What is Langrila?"
 retriever.run(query, filter=None).model_dump()
+
 >>> {'ids': [0],
  'documents': ['Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'],
  'metadatas': [{'collection': 'sample_0',

--- a/README.md
+++ b/README.md
@@ -601,8 +601,7 @@ retriever.run(query, filter=None).model_dump()
 
 >>> {'ids': [0],
  'documents': ['Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'],
- 'metadatas': [{'collection': 'sample_0',
-   'document': 'Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'}],
+ 'metadatas': [{'document': 'Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'}],
  'scores': [0.5303465176248179],
  'collections': ['sample_0'],
  'usage': {'prompt_tokens': 6, 'completion_tokens': 0}}
@@ -664,8 +663,7 @@ retriever.run(query, filter=None).model_dump()
 
 >>> {'ids': [0],
  'documents': ['Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'],
- 'metadatas': [{'collection': 'sample_0',
-   'document': 'Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'}],
+ 'metadatas': [{'document': 'Langrila is a useful tool to use ChatGPT with OpenAI API or Azure in an easy way.'}],
  'scores': [0.46960276455443584],
  'collections': ['sample_0'],
  'usage': {'prompt_tokens': 6, 'completion_tokens': 0}}

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ poetry add --editable /path/to/langrila/ --extras all
 <details>
 <summary>v0.0.7 -> v0.0.8</summary>
 
-Database modules has breaking changes such as rename of method, variable length argument of run/arun method of collection module apply to _upsert method instead of _create_collection method. For details, see change logs.
+Database modules has breaking changes from v0.0.7 to v0.0.8 such as rename of method, variable length argument of run/arun method in collection module apply to _upsert method instead of _create_collection method. For details, see change logs.
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langrila"
-version = "0.0.7"
+version = "0.0.8"
 description = "useful tool to use API-based LLM"
 authors = ["taikinman <okipedia6161@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,15 @@ openai = {version = "^1.31.1", optional = true}
 tiktoken = {version = "^0.7.0", optional = true}
 google-generativeai = {version = "^0.6.0", optional = true}
 qdrant-client = {version = "^1.9.1", optional = true}
+chromadb = {version = "^0.5.0", optional = true}
 
 
 [tool.poetry.extras]
 openai = ["openai", "tiktoken"]
 gemini = ["google-generativeai"]
 qdrant = ["qdrant-client"]
-all = ["openai", "tiktoken", "google-generativeai", "qdrant-client"]
+chroma = ["chromadb"]
+all = ["openai", "tiktoken", "google-generativeai", "qdrant-client", "chromadb"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -210,7 +210,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
         self,
         persistence_directory: Path | str,
         collection_name: str,
-        embedder: BaseEmbeddingModule = None,
+        embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
         limit_collection_size: int = 10000,
     ):

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -36,7 +36,10 @@ class AbstractLocalCollectionModule(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _create_collection(self, client: Any, collection_name: str, **kwargs) -> None:
+    def _create_collection(self, client: Any, collection_name: str) -> None:
+        """
+        create a collection
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -108,11 +111,17 @@ class AbstractRemoteCollectionModule(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _create_collection(self, client: Any, collection_name: str, **kwargs) -> None:
+    def _create_collection(self, client: Any, collection_name: str) -> None:
+        """
+        create a collection
+        """
         raise NotImplementedError
 
     @abstractmethod
-    async def _acreate_collection(self, client: Any, collection_name: str, **kwargs) -> None:
+    async def _acreate_collection(self, client: Any, collection_name: str) -> None:
+        """
+        create a collection
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -182,10 +191,10 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
         assert limit_collection_size % 100 == 0, "limit_collection_size must be multiple of 100."
         self.limit_collection_size: int = limit_collection_size
 
-    def create_collection(self, suffix: str = "", **kwargs) -> None:
+    def create_collection(self, suffix: str = "") -> None:
         client = self.get_client()
         colelction_name = self.collection_name + suffix
-        self._create_collection(client=client, collection_name=colelction_name, **kwargs)
+        self._create_collection(client=client, collection_name=colelction_name)
 
     def exists(self) -> bool:
         client = self.get_client()
@@ -263,9 +272,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
                 suffix: str = f"_{collection_index}"
                 collection_name: str = self.collection_name + suffix
                 if not self._exists(client=client, collection_name=collection_name):
-                    self._create_collection(
-                        client=client, collection_name=collection_name, **kwargs
-                    )
+                    self._create_collection(client=client, collection_name=collection_name)
                     self.logger.info(f"Create collection {collection_name}.")
 
             # self.logger.info(f"[batch {i+1}/{n_batches}] Upsert points...")
@@ -320,10 +327,10 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
         self.logger = logger or DefaultLogger()
         self.limit_collection_size: int = limit_collection_size
 
-    async def acreate_collection(self, suffix: str = "", **kwargs) -> None:
+    async def acreate_collection(self, suffix: str = "") -> None:
         client = self.get_async_client()
         colelction_name = self.collection_name + suffix
-        await self._acreate_collection(client=client, collection_name=colelction_name, **kwargs)
+        await self._acreate_collection(client=client, collection_name=colelction_name)
 
     async def aexists(self) -> bool:
         client = self.get_async_client()
@@ -400,9 +407,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
                 suffix: str = f"_{collection_index}"
                 collection_name: str = self.collection_name + suffix
                 if not await self._aexists(client=client, collection_name=collection_name):
-                    await self._acreate_collection(
-                        client=client, collection_name=collection_name, **kwargs
-                    )
+                    await self._acreate_collection(client=client, collection_name=collection_name)
                     self.logger.info(f"Create collection {collection_name}.")
 
             # self.logger.info(f"[batch {i+1}/{n_batches}] Upsert points...")

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -300,6 +300,21 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
 
         if metadatas is None:
             metadatas = [{} for _ in range(len(documents))]
+        else:
+            # check if the key 'collection' or 'document' is included in metadatas
+            assert len(documents) == len(
+                metadatas
+            ), "The length of documents and metadatas must be the same."
+
+            metadata_keys = [
+                metadata
+                for metadata in metadatas
+                if "collection" in metadata or "document" in metadata
+            ]
+            if len(metadata_keys) > 0:
+                raise ValueError(
+                    "The key 'collection' and 'document' are reserved and automatically included in metadata. Use another key."
+                )
 
         length = len(documents)
         ids = []
@@ -336,7 +351,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
             # self.logger.info(f"[batch {i+1}/{n_batches}] Upsert points...")
 
             metadata_batch = [
-                {"metadata": metadata, "collection": collection_name} for metadata in metadata_batch
+                metadata | {"collection": collection_name} for metadata in metadata_batch
             ]
 
             n_retries = 0
@@ -439,6 +454,21 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
 
         if metadatas is None:
             metadatas = [{} for _ in range(len(documents))]
+        else:
+            # check if the key 'collection' or 'document' is included in metadatas
+            assert len(documents) == len(
+                metadatas
+            ), "The length of documents and metadatas must be the same."
+
+            metadata_keys = [
+                metadata
+                for metadata in metadatas
+                if "collection" in metadata or "document" in metadata
+            ]
+            if len(metadata_keys) > 0:
+                raise ValueError(
+                    "The key 'collection' and 'document' are reserved and automatically included in metadata. Use another key."
+                )
 
         length = len(documents)
         ids = []

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -505,7 +505,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
             # self.logger.info(f"[batch {i+1}/{n_batches}] Upsert points...")
 
             metadata_batch = [
-                {"metadata": metadata, "collection": collection_name} for metadata in metadata_batch
+                metadata | {"collection": collection_name} for metadata in metadata_batch
             ]
 
             n_retries = 0

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -563,7 +563,7 @@ class BaseLocalRetrievalModule(AbstractLocalRetrievalModule):
         collection_name: str,
         embedder: BaseEmbeddingModule = None,
         n_results: int = 4,
-        score_threshold: float = 0.8,
+        score_threshold: float = 0.5,
         logger: Any | None = None,
         ascending: bool = False,
     ):
@@ -634,7 +634,7 @@ class BaseRemoteRetrievalModule(BaseLocalRetrievalModule, AbstractRemoteRetrieva
         port: str = "6333",
         embedder: BaseEmbeddingModule = None,
         n_results: int = 4,
-        score_threshold: float = 0.8,
+        score_threshold: float = 0.5,
         logger: Any | None = None,
         ascending: bool = False,
     ):

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -60,7 +60,17 @@ class AbstractLocalCollectionModule(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _delete(self, client: Any, collection_name: str) -> None:
+    def _delete_collection(self, client: Any, collection_name: str) -> None:
+        """
+        delete the collection
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _delete_record(self, client: Any, collection_name: str, id: int | str) -> None:
+        """
+        delete the record from the collection
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -159,11 +169,31 @@ class AbstractRemoteCollectionModule(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def _adelete(self, client: Any, collection_name: str) -> None:
+    async def _adelete_collection(self, client: Any, collection_name: str) -> None:
+        """
+        delete the collection
+        """
         raise NotImplementedError
 
     @abstractmethod
-    def _delete(self, client: Any, collection_name: str) -> None:
+    def _delete_collection(self, client: Any, collection_name: str) -> None:
+        """
+        delete the collection
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def _adelete_record(self, client: Any, collection_name: str, id: int | str) -> None:
+        """
+        delete the record from the collection
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _delete_record(self, client: Any, collection_name: str, id: int | str) -> None:
+        """
+        delete the record from the collection
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -219,12 +249,16 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
             **kwargs,
         )
 
-    def delete(self) -> None:
+    def delete_collection(self) -> None:
         client = self.get_client()
 
         for collection_name in self._glob(client=client):
             if self._exists(client=client, collection_name=collection_name):
-                self._delete(client=client, collection_name=collection_name)
+                self._delete_collection(client=client, collection_name=collection_name)
+
+    def delete_record(self, id: int | str) -> None:
+        client = self.get_client()
+        self._delete_record(client=client, collection_name=self.collection_name, id=id)
 
     def run(
         self,
@@ -355,11 +389,15 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
             **kwargs,
         )
 
-    async def adelete(self) -> None:
+    async def adelete_collection(self) -> None:
         client = self.get_async_client()
         for collection_name in await self._aglob(client=client):
             if await self._aexists(client=client, collection_name=collection_name):
-                await self._adelete(client=client, collection_name=collection_name)
+                await self._adelete_collection(client=client, collection_name=collection_name)
+
+    async def adelete_record(self, id: int | str) -> None:
+        client = self.get_async_client()
+        await self._adelete_record(client=client, collection_name=self.collection_name, id=id)
 
     async def arun(
         self,

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -49,6 +49,7 @@ class AbstractLocalCollectionModule(ABC):
         client: Any,
         collection_name: str,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -127,6 +128,7 @@ class AbstractRemoteCollectionModule(ABC):
         client: Any,
         collection_name: str,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -138,6 +140,7 @@ class AbstractRemoteCollectionModule(ABC):
         client: Any,
         collection_name: str,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -188,6 +191,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
     def upsert(
         self,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -196,6 +200,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
             client=client,
             collection_name=self.collection_name,
             ids=ids,
+            documents=documents,
             embeddings=embeddings,
             metadatas=metadatas,
         )
@@ -261,8 +266,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
             # self.logger.info(f"[batch {i+1}/{n_batches}] Upsert points...")
 
             metadata_batch = [
-                {"metadata": metadata, "document": document, "collection": collection_name}
-                for metadata, document in zip(metadata_batch, doc_batch, strict=True)
+                {"metadata": metadata, "collection": collection_name} for metadata in metadata_batch
             ]
 
             n_retries = 0
@@ -272,6 +276,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
                         client=client,
                         collection_name=collection_name,
                         ids=id_batch,
+                        documents=doc_batch,
                         embeddings=embedding_batch.embeddings,
                         metadatas=metadata_batch,
                     )
@@ -321,6 +326,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
     async def aupsert(
         self,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -329,6 +335,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
             client=client,
             collection_name=self.collection_name,
             ids=ids,
+            documents=documents,
             embeddings=embeddings,
             metadatas=metadatas,
         )
@@ -393,8 +400,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
             # self.logger.info(f"[batch {i+1}/{n_batches}] Upsert points...")
 
             metadata_batch = [
-                {"metadata": metadata, "document": document, "collection": collection_name}
-                for metadata, document in zip(metadata_batch, doc_batch, strict=True)
+                {"metadata": metadata, "collection": collection_name} for metadata in metadata_batch
             ]
 
             n_retries = 0
@@ -404,6 +410,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
                         client=client,
                         collection_name=collection_name,
                         ids=id_batch,
+                        documents=doc_batch,
                         embeddings=embedding_batch.embeddings,
                         metadatas=metadata_batch,
                     )

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -375,9 +375,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
             metadata for metadata in metadatas if "collection" in metadata or "document" in metadata
         ]
         if len(metadata_keys) > 0:
-            raise ValueError(
-                "The key 'collection' and 'document' are reserved and automatically included in metadata. Use another key."
-            )
+            raise ValueError("The key 'collection' and 'document' are reserved. Use another key.")
 
 
 class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollectionModule):

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -73,7 +73,7 @@ class AbstractLocalCollectionModule(ABC):
         self,
         n_results: int,
         score_threshold: float,
-    ):
+    ) -> "BaseLocalRetrievalModule":
         """
         return the retrieval module
         """
@@ -192,7 +192,7 @@ class AbstractRemoteCollectionModule(ABC):
         self,
         n_results: int,
         score_threshold: float,
-    ):
+    ) -> "BaseRemoteRetrievalModule":
         """
         return the retrieval module
         """

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -52,6 +52,7 @@ class AbstractLocalCollectionModule(ABC):
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         raise NotImplementedError
 
@@ -131,6 +132,7 @@ class AbstractRemoteCollectionModule(ABC):
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         raise NotImplementedError
 
@@ -143,6 +145,7 @@ class AbstractRemoteCollectionModule(ABC):
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         raise NotImplementedError
 
@@ -194,6 +197,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         client = self.get_client()
         self._upsert(
@@ -203,6 +207,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
             documents=documents,
             embeddings=embeddings,
             metadatas=metadatas,
+            **kwargs,
         )
 
     def delete(self) -> None:
@@ -279,6 +284,7 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
                         documents=doc_batch,
                         embeddings=embedding_batch.embeddings,
                         metadatas=metadata_batch,
+                        **kwargs,
                     )
                     break
                 except Exception as e:
@@ -329,6 +335,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         client = self.get_async_client()
         await self._aupsert(
@@ -338,6 +345,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
             documents=documents,
             embeddings=embeddings,
             metadatas=metadatas,
+            **kwargs,
         )
 
     async def adelete(self) -> None:
@@ -413,6 +421,7 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
                         documents=doc_batch,
                         embeddings=embedding_batch.embeddings,
                         metadatas=metadata_batch,
+                        **kwargs,
                     )
                     break
                 except Exception as e:

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -44,6 +44,9 @@ class AbstractLocalCollectionModule(ABC):
 
     @abstractmethod
     def _exists(self, client: Any, collection_name: str) -> bool:
+        """
+        check if the collection exists
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -57,6 +60,9 @@ class AbstractLocalCollectionModule(ABC):
         metadatas: list[dict[str, str]],
         **kwargs,
     ) -> None:
+        """
+        upsert embeddings, documents and metadatas
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -79,6 +85,9 @@ class AbstractLocalCollectionModule(ABC):
         n_results: int,
         score_threshold: float,
     ):
+        """
+        return the retrieval module
+        """
         raise NotImplementedError
 
 
@@ -136,10 +145,16 @@ class AbstractRemoteCollectionModule(ABC):
 
     @abstractmethod
     def _exists(self, client: Any, collection_name: str) -> bool:
+        """
+        check if the collection exists
+        """
         raise NotImplementedError
 
     @abstractmethod
     async def _aexists(self, client: Any, collection_name: str) -> bool:
+        """
+        check if the collection exists
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -153,6 +168,9 @@ class AbstractRemoteCollectionModule(ABC):
         metadatas: list[dict[str, str]],
         **kwargs,
     ) -> None:
+        """
+        upsert embeddings, documents and metadatas
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -166,6 +184,9 @@ class AbstractRemoteCollectionModule(ABC):
         metadatas: list[dict[str, str]],
         **kwargs,
     ) -> None:
+        """
+        upsert embeddings, documents and metadatas
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -202,6 +223,9 @@ class AbstractRemoteCollectionModule(ABC):
         n_results: int,
         score_threshold: float,
     ):
+        """
+        return the retrieval module
+        """
         raise NotImplementedError
 
 

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -61,7 +61,7 @@ class AbstractLocalCollectionModule(ABC):
         **kwargs,
     ) -> None:
         """
-        upsert embeddings, documents and metadatas. document and collection are reserved keys and must be included in metadata.
+        upsert embeddings, documents and metadatas.
         """
         raise NotImplementedError
 
@@ -169,7 +169,7 @@ class AbstractRemoteCollectionModule(ABC):
         **kwargs,
     ) -> None:
         """
-        upsert embeddings, documents and metadatas
+        upsert embeddings, documents and metadatas.
         """
         raise NotImplementedError
 
@@ -185,7 +185,7 @@ class AbstractRemoteCollectionModule(ABC):
         **kwargs,
     ) -> None:
         """
-        upsert embeddings, documents and metadatas. document and collection are reserved keys and must be included in metadata.
+        upsert embeddings, documents and metadatas.
         """
         raise NotImplementedError
 
@@ -369,13 +369,11 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
 
     def _verify_metadata(self, metadatas: list[dict[str, str]]) -> None:
         """
-        check if the key 'collection' or 'document' is included in metadatas
+        check if the key 'document' is included in metadatas
         """
-        metadata_keys = [
-            metadata for metadata in metadatas if "collection" in metadata or "document" in metadata
-        ]
+        metadata_keys = [metadata for metadata in metadatas if "document" in metadata]
         if len(metadata_keys) > 0:
-            raise ValueError("The key 'collection' and 'document' are reserved. Use another key.")
+            raise ValueError("The key 'document' is reserved. Use another key.")
 
 
 class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollectionModule):

--- a/src/langrila/database/base.py
+++ b/src/langrila/database/base.py
@@ -62,9 +62,9 @@ class AbstractLocalCollectionModule(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def _delete_record(self, client: Any, collection_name: str, id: int | str) -> None:
+    def _delete_record(self, client: Any, collection_name: str, **kwargs) -> None:
         """
-        delete the record from the collection
+        delete the record from the collection. kwargs depends on the clieint.
         """
         raise NotImplementedError
 
@@ -174,16 +174,16 @@ class AbstractRemoteCollectionModule(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def _adelete_record(self, client: Any, collection_name: str, id: int | str) -> None:
+    async def _adelete_record(self, client: Any, collection_name: str, **kwargs) -> None:
         """
-        delete the record from the collection
+        delete the record from the collection. kwargs depends on the clieint.
         """
         raise NotImplementedError
 
     @abstractmethod
-    def _delete_record(self, client: Any, collection_name: str, id: int | str) -> None:
+    def _delete_record(self, client: Any, collection_name: str, **kwargs) -> None:
         """
-        delete the record from the collection
+        delete the record from the collection. kwargs depends on the clieint.
         """
         raise NotImplementedError
 
@@ -246,9 +246,9 @@ class BaseLocalCollectionModule(AbstractLocalCollectionModule):
         if self._exists(client=client, collection_name=self.collection_name):
             self._delete_collection(client=client, collection_name=self.collection_name)
 
-    def delete_record(self, id: int | str) -> None:
+    def delete_record(self, **kwargs) -> None:
         client = self.get_client()
-        self._delete_record(client=client, collection_name=self.collection_name, id=id)
+        self._delete_record(client=client, collection_name=self.collection_name, **kwargs)
 
     def run(
         self,
@@ -369,9 +369,9 @@ class BaseRemoteCollectionModule(BaseLocalCollectionModule, AbstractRemoteCollec
         if await self._aexists(client=client, collection_name=self.collection_name):
             await self._adelete_collection(client=client, collection_name=self.collection_name)
 
-    async def adelete_record(self, id: int | str) -> None:
+    async def adelete_record(self, **kwargs) -> None:
         client = self.get_async_client()
-        await self._adelete_record(client=client, collection_name=self.collection_name, id=id)
+        await self._adelete_record(client=client, collection_name=self.collection_name, **kwargs)
 
     async def arun(
         self,

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -46,6 +46,7 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
         client: ClientAPI,
         collection_name: str,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -57,7 +58,7 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
         self.collection.upsert(
             ids=[str(i) for i in ids],
             embeddings=embeddings,
-            documents=[metadata["document"] for metadata in metadatas],
+            documents=documents,
             metadatas=[metadata["metadata"] for metadata in metadatas],
         )
 

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import chromadb
+from chromadb import DEFAULT_DATABASE, DEFAULT_TENANT
 from chromadb.api import ClientAPI
 
 from ..result import RetrievalResults

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -60,13 +60,13 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
         **kwargs,
     ) -> None:
         if not hasattr(self, "collection"):
-            self.collection = client.get_collection(name=collection_name, metadata=self.metadata)
+            self.collection = client.get_collection(name=collection_name)
 
         self.collection.upsert(
             ids=[str(i) for i in ids],
             embeddings=embeddings,
             documents=documents,
-            metadatas=[metadata["metadata"] for metadata in metadatas],
+            metadatas=[m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)],
             **kwargs,
         )
 

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -66,7 +66,10 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
             ids=[str(i) for i in ids],
             embeddings=embeddings,
             documents=documents,
-            metadatas=[m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)],
+            metadatas=[
+                m | {"document": doc, "collection": collection_name}
+                for m, doc in zip(metadatas, documents, strict=True)
+            ],
             **kwargs,
         )
 

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -66,10 +66,7 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
             ids=[str(i) for i in ids],
             embeddings=embeddings,
             documents=documents,
-            metadatas=[
-                m | {"document": doc, "collection": collection_name}
-                for m, doc in zip(metadatas, documents, strict=True)
-            ],
+            metadatas=[m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)],
             **kwargs,
         )
 

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -1,0 +1,160 @@
+from typing import Any
+
+import chromadb
+from chromadb.api import ClientAPI
+
+from ..result import RetrievalResults
+from .base import (
+    BaseEmbeddingModule,
+    BaseLocalCollectionModule,
+    BaseLocalRetrievalModule,
+)
+
+
+class ChromaLocalCollectionModule(BaseLocalCollectionModule):
+    def __init__(
+        self,
+        persistence_directory: str,
+        collection_name: str,
+        distance: str = "cosine",
+        embedder: BaseEmbeddingModule | None = None,
+        logger: Any | None = None,
+        limit_collection_size: int = 10000,
+    ):
+        super().__init__(
+            persistence_directory=persistence_directory,
+            collection_name=collection_name,
+            embedder=embedder,
+            logger=logger,
+            limit_collection_size=limit_collection_size,
+        )
+        self.distance = distance
+
+    def _glob(self, client: ClientAPI) -> list[str]:
+        return [c.name for c in client.list_collections() if self.collection_name in c.name]
+
+    def _exists(self, client: ClientAPI, collection_name: str) -> bool:
+        return len([name for name in self._glob(client=client) if name == collection_name]) > 0
+
+    def _create_collection(self, client: ClientAPI, collection_name: str, **kwargs) -> None:
+        self.collection = client.create_collection(
+            name=collection_name, metadata={"hnsw:space": self.distance}, **kwargs
+        )
+
+    def _upsert(
+        self,
+        client: ClientAPI,
+        collection_name: str,
+        ids: list[str | int],
+        embeddings: list[list[float]],
+        metadatas: list[dict[str, str]],
+    ) -> None:
+        if not hasattr(self, "collection"):
+            self.collection = client.get_collection(
+                name=collection_name, metadata={"hnsw:space": self.distance}
+            )
+
+        self.collection.upsert(
+            ids=[str(i) for i in ids],
+            embeddings=embeddings,
+            documents=[metadata["document"] for metadata in metadatas],
+            metadatas=[metadata["metadata"] for metadata in metadatas],
+        )
+
+        return
+
+    def _delete(self, client: ClientAPI, collection_name: str) -> None:
+        client.delete_collection(name=collection_name)
+
+    def get_client(self) -> ClientAPI:
+        return chromadb.PersistentClient(path=self.persistence_directory.as_posix())
+
+    def as_retriever(
+        self,
+        n_results: int = 4,
+        score_threshold: float = 0.5,
+    ) -> "ChromaLocalRetrievalModule":
+        return ChromaLocalRetrievalModule(
+            embedder=self.embedder,
+            persistence_directory=self.persistence_directory,
+            collection_name=self.collection_name,
+            n_results=n_results,
+            score_threshold=score_threshold,
+            logger=self.logger,
+        )
+
+
+class ChromaLocalRetrievalModule(BaseLocalRetrievalModule):
+    def __init__(
+        self,
+        persistence_directory: str,
+        collection_name: str,
+        embedder: BaseEmbeddingModule | None = None,
+        n_results: int = 4,
+        score_threshold: float = 0.5,
+        logger: Any | None = None,
+        ascending: bool = True,
+    ):
+        super().__init__(
+            persistence_directory=persistence_directory,
+            collection_name=collection_name,
+            embedder=embedder,
+            n_results=n_results,
+            score_threshold=score_threshold,
+            logger=logger,
+            ascending=ascending,
+        )
+
+    def get_client(self) -> ClientAPI:
+        return chromadb.PersistentClient(path=self.persistence_directory.as_posix())
+
+    def _glob(self, client: ClientAPI) -> list[str]:
+        return [c.name for c in client.list_collections() if self.collection_name in c.name]
+
+    def _retrieve(
+        self,
+        client: ClientAPI,
+        collection_name: str,
+        query_vector: list[float],
+        n_results: int,
+        score_threshold: float,
+        filter: Any | None = None,
+        **kwargs,
+    ) -> RetrievalResults:
+        collection = client.get_collection(name=collection_name)
+
+        retrieved = collection.query(
+            query_embeddings=query_vector,
+            where=filter,
+            include=["metadatas", "documents", "distances"],
+            n_results=n_results,
+            **kwargs,
+        )
+
+        ids = []
+        scores = []
+        documents = []
+        metadatas = []
+        collections = []
+
+        for _id, dist, document, metadata in zip(
+            retrieved["ids"][0],
+            retrieved["distances"][0],
+            retrieved["documents"][0],
+            retrieved["metadatas"][0],
+            strict=True,
+        ):
+            if dist <= score_threshold:
+                ids.append(int(_id))
+                scores.append(dist)
+                documents.append(document)
+                metadatas.append(metadata)
+                collections.append(collection_name)
+
+        return RetrievalResults(
+            ids=ids,
+            scores=scores,
+            documents=documents,
+            metadatas=metadatas,
+            collections=collections,
+        )

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -3,6 +3,7 @@ from typing import Any
 import chromadb
 from chromadb import DEFAULT_DATABASE, DEFAULT_TENANT
 from chromadb.api import ClientAPI
+from chromadb.types import Where
 
 from ..result import RetrievalResults
 from .base import (
@@ -17,7 +18,7 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
         self,
         persistence_directory: str,
         collection_name: str,
-        metadata: dict[str, str] | None = None,
+        metadata: dict[str, Any] | None = None,
         embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
         tenant: str = DEFAULT_TENANT,
@@ -39,10 +40,17 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
     def _create_collection(self, client: ClientAPI, collection_name: str) -> None:
         self.collection = client.create_collection(name=collection_name, metadata=self.metadata)
 
-    def _delete_record(self, client: ClientAPI, collection_name: str, ids: list[str | int]) -> None:
+    def _delete_record(
+        self,
+        client: ClientAPI,
+        collection_name: str,
+        ids: list[str | int],
+        filter: Where | None = None,
+        **kwargs,
+    ) -> None:
         if not hasattr(self, "collection"):
             self.collection = client.get_collection(name=collection_name)
-        self.collection.delete(ids=[str(i) for i in ids])
+        self.collection.delete(ids=[str(i) for i in ids], where=filter, **kwargs)
 
     def _upsert(
         self,

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -71,7 +71,7 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
 
         return
 
-    def _delete(self, client: ClientAPI, collection_name: str) -> None:
+    def _delete_collection(self, client: ClientAPI, collection_name: str) -> None:
         client.delete_collection(name=collection_name)
 
     def get_client(self) -> ClientAPI:

--- a/src/langrila/database/chroma.py
+++ b/src/langrila/database/chroma.py
@@ -49,6 +49,7 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         if not hasattr(self, "collection"):
             self.collection = client.get_collection(
@@ -60,6 +61,7 @@ class ChromaLocalCollectionModule(BaseLocalCollectionModule):
             embeddings=embeddings,
             documents=documents,
             metadatas=[metadata["metadata"] for metadata in metadatas],
+            **kwargs,
         )
 
         return

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -110,8 +110,14 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
     def _delete_collection(self, client: QdrantClient, collection_name: str) -> None:
         client.delete_collection(collection_name=collection_name)
 
-    def _delete_record(self, client: QdrantClient, collection_name: str, id: int | str) -> None:
-        client.delete(collection_name=collection_name, points_selector=[id])
+    def _delete_record(
+        self,
+        client: QdrantClient,
+        collection_name: str,
+        points_selector: types.PointsSelector,
+        **kwargs,
+    ) -> None:
+        client.delete(collection_name=collection_name, points_selector=points_selector, **kwargs)
 
     def get_client(self) -> QdrantClient:
         return QdrantClient(path=self.persistence_directory)
@@ -234,8 +240,14 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
     def _delete_collection(self, client: QdrantClient, collection_name: str) -> None:
         client.delete_collection(collection_name=collection_name)
 
-    def _delete_record(self, client: QdrantClient, collection_name: str, id: int | str) -> None:
-        client.delete(collection_name=collection_name, points_selector=[id])
+    def _delete_record(
+        self,
+        client: QdrantClient,
+        collection_name: str,
+        points_selector: types.PointsSelector,
+        **kwargs,
+    ) -> None:
+        client.delete(collection_name=collection_name, points_selector=points_selector, **kwargs)
 
     async def _aexists(self, client: AsyncQdrantClient, collection_name: str) -> bool:
         return await client.collection_exists(collection_name=collection_name)
@@ -286,9 +298,15 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         await client.delete_collection(collection_name=collection_name)
 
     async def _adelete_record(
-        self, client: QdrantClient, collection_name: str, id: int | str, **kwargs
+        self,
+        client: AsyncQdrantClient,
+        collection_name: str,
+        points_selector: types.PointsSelector,
+        **kwargs,
     ) -> None:
-        await client.delete(collection_name=collection_name, points_selector=[id], **kwargs)
+        await client.delete(
+            collection_name=collection_name, points_selector=points_selector, **kwargs
+        )
 
     def get_client(self) -> QdrantClient:
         if hasattr(self, "client"):

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -106,8 +106,7 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
                 ids=ids,
                 vectors=embeddings,
                 payloads=[
-                    m | {"document": doc, "collection": collection_name}
-                    for m, doc in zip(metadatas, documents, strict=True)
+                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)
                 ],
             ),
             **kwargs,
@@ -238,8 +237,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
                 ids=ids,
                 vectors=embeddings,
                 payloads=[
-                    m | {"document": doc, "collection": collection_name}
-                    for m, doc in zip(metadatas, documents, strict=True)
+                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)
                 ],
             ),
             **kwargs,
@@ -297,8 +295,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
                 ids=ids,
                 vectors=embeddings,
                 payloads=[
-                    m | {"document": doc, "collection": collection_name}
-                    for m, doc in zip(metadatas, documents, strict=True)
+                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)
                 ],
             ),
             **kwargs,
@@ -415,7 +412,7 @@ class QdrantLocalRetrievalModule(BaseLocalRetrievalModule):
         scores = [r.score for r in retrieved]
         documents = [r.payload["document"] for r in retrieved]
         metadatas = [r.payload for r in retrieved]
-        collections = [r.payload["collection"] for r in retrieved]
+        collections = [collection_name for _ in retrieved]
 
         return RetrievalResults(
             ids=ids,
@@ -522,7 +519,7 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
         scores = [r.score for r in retrieved]
         documents = [r.payload["document"] for r in retrieved]
         metadatas = [r.payload for r in retrieved]
-        collections = [r.payload["collection"] for r in retrieved]
+        collections = [collection_name for _ in retrieved]
 
         return RetrievalResults(
             ids=ids,

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -106,7 +106,8 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
                 ids=ids,
                 vectors=embeddings,
                 payloads=[
-                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
+                    m | {"document": doc, "collection": collection_name}
+                    for m, doc in zip(metadatas, documents, strict=True)
                 ],
             ),
             **kwargs,
@@ -237,7 +238,8 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
                 ids=ids,
                 vectors=embeddings,
                 payloads=[
-                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)
+                    m | {"document": doc, "collection": collection_name}
+                    for m, doc in zip(metadatas, documents, strict=True)
                 ],
             ),
             **kwargs,
@@ -295,7 +297,8 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
                 ids=ids,
                 vectors=embeddings,
                 payloads=[
-                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)
+                    m | {"document": doc, "collection": collection_name}
+                    for m, doc in zip(metadatas, documents, strict=True)
                 ],
             ),
             **kwargs,

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -29,7 +29,6 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
         vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
         embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
-        on_disk: bool = False,
         limit_collection_size: int = 10000,
         sparse_vectors_config: Optional[Mapping[str, types.SparseVectorParams]] = None,
         shard_number: Optional[int] = None,
@@ -144,12 +143,9 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         self,
         url: str,
         collection_name: str,
-        vector_size: int,
         port: str = "6333",
-        distance: Distance = Distance.COSINE,
         embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
-        on_disk: bool = False,
         limit_collection_size: int = 10000,
         https: bool | None = None,
         api_key_env_name: str | None = None,
@@ -171,10 +167,6 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         init_from: Optional[types.InitFrom] = None,
         timeout: Optional[int] = None,
     ):
-        self.vector_size = vector_size
-        self.distance = distance
-        self.on_disk = on_disk
-
         super().__init__(
             collection_name=collection_name,
             embedder=embedder,

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -1,7 +1,15 @@
-from typing import Any, Optional
+import os
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Mapping,
+    Optional,
+    Union,
+)
 
 from qdrant_client import AsyncQdrantClient, QdrantClient, models
-from qdrant_client.models import Distance, VectorParams
+from qdrant_client.conversions import common_types as types
 
 from ..result import RetrievalResults
 from .base import (

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -127,7 +127,7 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
     def as_retriever(
         self,
         n_results: int = 4,
-        score_threshold: float = 0.8,
+        score_threshold: float = 0.5,
     ) -> "QdrantLocalRetrievalModule":
         return QdrantLocalRetrievalModule(
             embedder=self.embedder,
@@ -354,7 +354,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
     def as_retriever(
         self,
         n_results: int = 4,
-        score_threshold: float = 0.8,
+        score_threshold: float = 0.5,
     ) -> "QdrantRemoteRetrievalModule":
         return QdrantRemoteRetrievalModule(
             embedder=self.embedder,
@@ -374,7 +374,7 @@ class QdrantLocalRetrievalModule(BaseLocalRetrievalModule):
         collection_name: str,
         embedder: BaseEmbeddingModule | None = None,
         n_results: int = 4,
-        score_threshold: float = 0.8,
+        score_threshold: float = 0.5,
         logger: Any | None = None,
         ascending: bool = False,
     ):
@@ -439,7 +439,7 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
         port: str = "6333",
         embedder: BaseEmbeddingModule | None = None,
         n_results: int = 4,
-        score_threshold: float = 0.8,
+        score_threshold: float = 0.5,
         logger: Any | None = None,
         ascending: bool = False,
         https: bool | None = None,

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -60,6 +60,7 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
         client: QdrantClient,
         collection_name: str,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -68,7 +69,9 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
             points=models.Batch(
                 ids=ids,
                 vectors=embeddings,
-                payloads=metadatas,
+                payloads=[
+                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
+                ],
             ),
         )
 
@@ -145,6 +148,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         client: QdrantClient,
         collection_name: str,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -153,7 +157,9 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
             points=models.Batch(
                 ids=ids,
                 vectors=embeddings,
-                payloads=metadatas,
+                payloads=[
+                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
+                ],
             ),
         )
 
@@ -190,6 +196,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         client: AsyncQdrantClient,
         collection_name: str,
         ids: list[str | int],
+        documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
     ) -> None:
@@ -198,7 +205,9 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
             points=models.Batch(
                 ids=ids,
                 vectors=embeddings,
-                payloads=metadatas,
+                payloads=[
+                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
+                ],
             ),
         )
 

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -63,6 +63,7 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         client.upsert(
             collection_name=collection_name,
@@ -73,6 +74,7 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
                     m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
                 ],
             ),
+            **kwargs,
         )
 
         return
@@ -151,6 +153,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         client.upsert(
             collection_name=collection_name,
@@ -161,6 +164,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
                     m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
                 ],
             ),
+            **kwargs,
         )
 
         return
@@ -199,6 +203,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         documents: list[str],
         embeddings: list[list[float]],
         metadatas: list[dict[str, str]],
+        **kwargs,
     ) -> None:
         await client.upsert(
             collection_name=collection_name,
@@ -209,6 +214,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
                     m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
                 ],
             ),
+            **kwargs,
         )
 
         return

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -29,7 +29,6 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
         vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
         embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
-        limit_collection_size: int = 10000,
         sparse_vectors_config: Optional[Mapping[str, types.SparseVectorParams]] = None,
         shard_number: Optional[int] = None,
         sharding_method: Optional[types.ShardingMethod] = None,
@@ -48,7 +47,6 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
             collection_name=collection_name,
             embedder=embedder,
             logger=logger,
-            limit_collection_size=limit_collection_size,
         )
         self.vectors_config = vectors_config
         self.sparse_vectors_config = sparse_vectors_config
@@ -63,11 +61,6 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
         self.quantization_config = quantization_config
         self.init_from = init_from
         self.timeout = timeout
-
-    def _glob(self, client: QdrantClient) -> list[str]:
-        return [
-            c.name for c in client.get_collections().collections if self.collection_name in c.name
-        ]
 
     def _exists(self, client: QdrantClient, collection_name: str) -> bool:
         return client.collection_exists(collection_name=collection_name)
@@ -146,7 +139,6 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         port: str = "6333",
         embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
-        limit_collection_size: int = 10000,
         https: bool | None = None,
         api_key_env_name: str | None = None,
         host: str | None = None,
@@ -173,7 +165,6 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
             logger=logger,
             url=url,
             port=port,
-            limit_collection_size=limit_collection_size,
         )
         self.https = https
         self.api_key_env_name = api_key_env_name
@@ -194,11 +185,6 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         self.quantization_config = quantization_config
         self.init_from = init_from
         self.timeout = timeout
-
-    def _glob(self, client: QdrantClient) -> list[str]:
-        return [
-            c.name for c in client.get_collections().collections if self.collection_name in c.name
-        ]
 
     def _exists(self, client: QdrantClient, collection_name: str) -> bool:
         return client.collection_exists(collection_name=collection_name)
@@ -250,13 +236,6 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
 
     def _delete_record(self, client: QdrantClient, collection_name: str, id: int | str) -> None:
         client.delete(collection_name=collection_name, points_selector=[id])
-
-    async def _aglob(self, client: AsyncQdrantClient) -> list[str]:
-        return [
-            c.name
-            for c in (await client.get_collections()).collections
-            if self.collection_name in c.name
-        ]
 
     async def _aexists(self, client: AsyncQdrantClient, collection_name: str) -> bool:
         return await client.collection_exists(collection_name=collection_name)
@@ -383,11 +362,6 @@ class QdrantLocalRetrievalModule(BaseLocalRetrievalModule):
     def get_client(self) -> QdrantClient:
         return QdrantClient(path=self.persistence_directory)
 
-    def _glob(self, client: QdrantClient) -> list[str]:
-        return [
-            c.name for c in client.get_collections().collections if self.collection_name in c.name
-        ]
-
     def _retrieve(
         self,
         client: QdrantClient,
@@ -490,11 +464,6 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
         )
         return self.client
 
-    def _glob(self, client: QdrantClient) -> list[str]:
-        return [
-            c.name for c in client.get_collections().collections if self.collection_name in c.name
-        ]
-
     def _retrieve(
         self,
         client: QdrantClient,
@@ -528,13 +497,6 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
             metadatas=metadatas,
             collections=collections,
         )
-
-    async def _aglob(self, client: AsyncQdrantClient) -> list[str]:
-        return [
-            c.name
-            for c in (await client.get_collections()).collections
-            if self.collection_name in c.name
-        ]
 
     async def _aretrieve(
         self,

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -107,8 +107,11 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
 
         return
 
-    def _delete(self, client: QdrantClient, collection_name: str) -> None:
+    def _delete_collection(self, client: QdrantClient, collection_name: str) -> None:
         client.delete_collection(collection_name=collection_name)
+
+    def _delete_record(self, client: QdrantClient, collection_name: str, id: int | str) -> None:
+        client.delete(collection_name=collection_name, points_selector=[id])
 
     def get_client(self) -> QdrantClient:
         return QdrantClient(path=self.persistence_directory)
@@ -242,8 +245,11 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
 
         return
 
-    def _delete(self, client: QdrantClient, collection_name: str) -> None:
+    def _delete_collection(self, client: QdrantClient, collection_name: str) -> None:
         client.delete_collection(collection_name=collection_name)
+
+    def _delete_record(self, client: QdrantClient, collection_name: str, id: int | str) -> None:
+        client.delete(collection_name=collection_name, points_selector=[id])
 
     async def _aglob(self, client: AsyncQdrantClient) -> list[str]:
         return [
@@ -297,8 +303,13 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
 
         return
 
-    async def _adelete(self, client: AsyncQdrantClient, collection_name: str) -> None:
+    async def _adelete_collection(self, client: AsyncQdrantClient, collection_name: str) -> None:
         await client.delete_collection(collection_name=collection_name)
+
+    async def _adelete_record(
+        self, client: QdrantClient, collection_name: str, id: int | str, **kwargs
+    ) -> None:
+        await client.delete(collection_name=collection_name, points_selector=[id], **kwargs)
 
     def get_client(self) -> QdrantClient:
         if hasattr(self, "client"):

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -23,12 +23,14 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
         embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
         on_disk: bool = False,
+        limit_collection_size: int = 10000,
     ):
         super().__init__(
             persistence_directory=persistence_directory,
             collection_name=collection_name,
             embedder=embedder,
             logger=logger,
+            limit_collection_size=limit_collection_size,
         )
         self.vector_size = vector_size
         self.distance = distance
@@ -104,6 +106,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
         on_disk: bool = False,
+        limit_collection_size: int = 10000,
     ):
         self.vector_size = vector_size
         self.distance = distance
@@ -115,6 +118,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
             logger=logger,
             url=url,
             port=port,
+            limit_collection_size=limit_collection_size,
         )
 
     def _glob(self, client: QdrantClient) -> list[str]:
@@ -234,6 +238,7 @@ class QdrantLocalRetrievalModule(BaseLocalRetrievalModule):
         n_results: int = 4,
         score_threshold: float = 0.8,
         logger: Any | None = None,
+        ascending: bool = False,
     ):
         super().__init__(
             persistence_directory=persistence_directory,
@@ -242,6 +247,7 @@ class QdrantLocalRetrievalModule(BaseLocalRetrievalModule):
             n_results=n_results,
             score_threshold=score_threshold,
             logger=logger,
+            ascending=ascending,
         )
 
     def get_client(self) -> QdrantClient:
@@ -297,6 +303,7 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
         n_results: int = 4,
         score_threshold: float = 0.8,
         logger: Any | None = None,
+        ascending: bool = False,
     ):
         super().__init__(
             collection_name=collection_name,
@@ -306,6 +313,7 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
             logger=logger,
             url=url,
             port=port,
+            ascending=ascending,
         )
 
     def get_client(self) -> QdrantClient:

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -237,7 +237,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
                 ids=ids,
                 vectors=embeddings,
                 payloads=[
-                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
+                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)
                 ],
             ),
             **kwargs,
@@ -295,7 +295,7 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
                 ids=ids,
                 vectors=embeddings,
                 payloads=[
-                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=False)
+                    m | {"document": doc} for m, doc in zip(metadatas, documents, strict=True)
                 ],
             ),
             **kwargs,
@@ -411,7 +411,7 @@ class QdrantLocalRetrievalModule(BaseLocalRetrievalModule):
         ids = [r.id for r in retrieved]
         scores = [r.score for r in retrieved]
         documents = [r.payload["document"] for r in retrieved]
-        metadatas = [r.payload["metadata"] for r in retrieved]
+        metadatas = [r.payload for r in retrieved]
         collections = [r.payload["collection"] for r in retrieved]
 
         return RetrievalResults(
@@ -518,7 +518,7 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
         ids = [r.id for r in retrieved]
         scores = [r.score for r in retrieved]
         documents = [r.payload["document"] for r in retrieved]
-        metadatas = [r.payload["metadata"] for r in retrieved]
+        metadatas = [r.payload for r in retrieved]
         collections = [r.payload["collection"] for r in retrieved]
 
         return RetrievalResults(

--- a/src/langrila/database/qdrant.py
+++ b/src/langrila/database/qdrant.py
@@ -18,12 +18,23 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
         self,
         persistence_directory: str,
         collection_name: str,
-        vector_size: int,
-        distance: Distance = Distance.COSINE,
+        vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]],
         embedder: BaseEmbeddingModule | None = None,
         logger: Any | None = None,
         on_disk: bool = False,
         limit_collection_size: int = 10000,
+        sparse_vectors_config: Optional[Mapping[str, types.SparseVectorParams]] = None,
+        shard_number: Optional[int] = None,
+        sharding_method: Optional[types.ShardingMethod] = None,
+        replication_factor: Optional[int] = None,
+        write_consistency_factor: Optional[int] = None,
+        on_disk_payload: Optional[bool] = None,
+        hnsw_config: Optional[types.HnswConfigDiff] = None,
+        optimizers_config: Optional[types.OptimizersConfigDiff] = None,
+        wal_config: Optional[types.WalConfigDiff] = None,
+        quantization_config: Optional[types.QuantizationConfig] = None,
+        init_from: Optional[types.InitFrom] = None,
+        timeout: Optional[int] = None,
     ):
         super().__init__(
             persistence_directory=persistence_directory,
@@ -32,9 +43,19 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
             logger=logger,
             limit_collection_size=limit_collection_size,
         )
-        self.vector_size = vector_size
-        self.distance = distance
-        self.on_disk = on_disk
+        self.vectors_config = vectors_config
+        self.sparse_vectors_config = sparse_vectors_config
+        self.shard_number = shard_number
+        self.sharding_method = sharding_method
+        self.replication_factor = replication_factor
+        self.write_consistency_factor = write_consistency_factor
+        self.on_disk_payload = on_disk_payload
+        self.hnsw_config = hnsw_config
+        self.optimizers_config = optimizers_config
+        self.wal_config = wal_config
+        self.quantization_config = quantization_config
+        self.init_from = init_from
+        self.timeout = timeout
 
     def _glob(self, client: QdrantClient) -> list[str]:
         return [
@@ -44,15 +65,22 @@ class QdrantLocalCollectionModule(BaseLocalCollectionModule):
     def _exists(self, client: QdrantClient, collection_name: str) -> bool:
         return client.collection_exists(collection_name=collection_name)
 
-    def _create_collection(self, client: QdrantClient, collection_name: str, **kwargs) -> None:
+    def _create_collection(self, client: QdrantClient, collection_name: str) -> None:
         client.create_collection(
             collection_name=collection_name,
-            vectors_config=VectorParams(
-                size=self.vector_size,
-                distance=self.distance,
-                on_disk=self.on_disk,
-            ),
-            **kwargs,
+            vectors_config=self.vectors_config,
+            sparse_vectors_config=self.sparse_vectors_config,
+            shard_number=self.shard_number,
+            sharding_method=self.sharding_method,
+            replication_factor=self.replication_factor,
+            write_consistency_factor=self.write_consistency_factor,
+            on_disk_payload=self.on_disk_payload,
+            hnsw_config=self.hnsw_config,
+            optimizers_config=self.optimizers_config,
+            wal_config=self.wal_config,
+            quantization_config=self.quantization_config,
+            init_from=self.init_from,
+            timeout=self.timeout,
         )
 
     def _upsert(
@@ -112,6 +140,25 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         logger: Any | None = None,
         on_disk: bool = False,
         limit_collection_size: int = 10000,
+        https: bool | None = None,
+        api_key_env_name: str | None = None,
+        host: str | None = None,
+        grpc_port: str | None = "6334",
+        grpc_options: Optional[dict[str, Any]] = None,
+        auth_token_provider: Union[Callable[[], str], Callable[[], Awaitable[str]]] | None = None,
+        vectors_config: Union[types.VectorParams, Mapping[str, types.VectorParams]] = None,
+        sparse_vectors_config: Optional[Mapping[str, types.SparseVectorParams]] = None,
+        shard_number: Optional[int] = None,
+        sharding_method: Optional[types.ShardingMethod] = None,
+        replication_factor: Optional[int] = None,
+        write_consistency_factor: Optional[int] = None,
+        on_disk_payload: Optional[bool] = None,
+        hnsw_config: Optional[types.HnswConfigDiff] = None,
+        optimizers_config: Optional[types.OptimizersConfigDiff] = None,
+        wal_config: Optional[types.WalConfigDiff] = None,
+        quantization_config: Optional[types.QuantizationConfig] = None,
+        init_from: Optional[types.InitFrom] = None,
+        timeout: Optional[int] = None,
     ):
         self.vector_size = vector_size
         self.distance = distance
@@ -125,6 +172,25 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
             port=port,
             limit_collection_size=limit_collection_size,
         )
+        self.https = https
+        self.api_key_env_name = api_key_env_name
+        self.host = host
+        self.grpc_port = grpc_port
+        self.grpc_options = grpc_options
+        self.auth_token_provider = auth_token_provider
+        self.vectors_config = vectors_config
+        self.sparse_vectors_config = sparse_vectors_config
+        self.shard_number = shard_number
+        self.sharding_method = sharding_method
+        self.replication_factor = replication_factor
+        self.write_consistency_factor = write_consistency_factor
+        self.on_disk_payload = on_disk_payload
+        self.hnsw_config = hnsw_config
+        self.optimizers_config = optimizers_config
+        self.wal_config = wal_config
+        self.quantization_config = quantization_config
+        self.init_from = init_from
+        self.timeout = timeout
 
     def _glob(self, client: QdrantClient) -> list[str]:
         return [
@@ -134,15 +200,22 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
     def _exists(self, client: QdrantClient, collection_name: str) -> bool:
         return client.collection_exists(collection_name=collection_name)
 
-    def _create_collection(self, client: QdrantClient, collection_name: str, **kwargs) -> None:
+    def _create_collection(self, client: QdrantClient, collection_name: str) -> None:
         client.create_collection(
             collection_name=collection_name,
-            vectors_config=VectorParams(
-                size=self.vector_size,
-                distance=self.distance,
-                on_disk=self.on_disk,
-            ),
-            **kwargs,
+            vectors_config=self.vectors_config,
+            sparse_vectors_config=self.sparse_vectors_config,
+            shard_number=self.shard_number,
+            sharding_method=self.sharding_method,
+            replication_factor=self.replication_factor,
+            write_consistency_factor=self.write_consistency_factor,
+            on_disk_payload=self.on_disk_payload,
+            hnsw_config=self.hnsw_config,
+            optimizers_config=self.optimizers_config,
+            wal_config=self.wal_config,
+            quantization_config=self.quantization_config,
+            init_from=self.init_from,
+            timeout=self.timeout,
         )
 
     def _upsert(
@@ -182,17 +255,22 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
     async def _aexists(self, client: AsyncQdrantClient, collection_name: str) -> bool:
         return await client.collection_exists(collection_name=collection_name)
 
-    async def _acreate_collection(
-        self, client: AsyncQdrantClient, collection_name: str, **kwargs
-    ) -> None:
+    async def _acreate_collection(self, client: AsyncQdrantClient, collection_name: str) -> None:
         await client.create_collection(
             collection_name=collection_name,
-            vectors_config=VectorParams(
-                size=self.vector_size,
-                distance=self.distance,
-                on_disk=self.on_disk,
-            ),
-            **kwargs,
+            vectors_config=self.vectors_config,
+            sparse_vectors_config=self.sparse_vectors_config,
+            shard_number=self.shard_number,
+            sharding_method=self.sharding_method,
+            replication_factor=self.replication_factor,
+            write_consistency_factor=self.write_consistency_factor,
+            on_disk_payload=self.on_disk_payload,
+            hnsw_config=self.hnsw_config,
+            optimizers_config=self.optimizers_config,
+            wal_config=self.wal_config,
+            quantization_config=self.quantization_config,
+            init_from=self.init_from,
+            timeout=self.timeout,
         )
 
     async def _aupsert(
@@ -223,10 +301,36 @@ class QdrantRemoteCollectionModule(BaseRemoteCollectionModule):
         await client.delete_collection(collection_name=collection_name)
 
     def get_client(self) -> QdrantClient:
-        return QdrantClient(url=self.url, port=self.port)
+        if hasattr(self, "client"):
+            return self.client
+
+        self.client = QdrantClient(
+            url=self.url,
+            port=self.port,
+            https=self.https,
+            api_key=os.getenv(self.api_key_env_name) if self.api_key_env_name else None,
+            host=self.host,
+            grpc_port=self.grpc_port,
+            grpc_options=self.grpc_options,
+            auth_token_provider=self.auth_token_provider,
+        )
+        return self.client
 
     def get_async_client(self) -> AsyncQdrantClient:
-        return AsyncQdrantClient(url=self.url, port=self.port)
+        if hasattr(self, "client"):
+            return self.client
+
+        self.client = AsyncQdrantClient(
+            url=self.url,
+            port=self.port,
+            https=self.https,
+            api_key=os.getenv(self.api_key_env_name) if self.api_key_env_name else None,
+            host=self.host,
+            grpc_port=self.grpc_port,
+            grpc_options=self.grpc_options,
+            auth_token_provider=self.auth_token_provider,
+        )
+        return self.client
 
     def as_retriever(
         self,
@@ -319,6 +423,12 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
         score_threshold: float = 0.8,
         logger: Any | None = None,
         ascending: bool = False,
+        https: bool | None = None,
+        api_key_env_name: str | None = None,
+        host: str | None = None,
+        grpc_port: str | None = "6334",
+        grpc_options: Optional[dict[str, Any]] = None,
+        auth_token_provider: Union[Callable[[], str], Callable[[], Awaitable[str]]] | None = None,
     ):
         super().__init__(
             collection_name=collection_name,
@@ -330,12 +440,44 @@ class QdrantRemoteRetrievalModule(BaseRemoteRetrievalModule):
             port=port,
             ascending=ascending,
         )
+        self.https = https
+        self.api_key_env_name = api_key_env_name
+        self.host = host
+        self.grpc_port = grpc_port
+        self.grpc_options = grpc_options
+        self.auth_token_provider = auth_token_provider
 
     def get_client(self) -> QdrantClient:
-        return QdrantClient(url=self.url, port=self.port)
+        if hasattr(self, "client"):
+            return self.client
+
+        self.client = QdrantClient(
+            url=self.url,
+            port=self.port,
+            https=self.https,
+            api_key=os.getenv(self.api_key_env_name) if self.api_key_env_name else None,
+            host=self.host,
+            grpc_port=self.grpc_port,
+            grpc_options=self.grpc_options,
+            auth_token_provider=self.auth_token_provider,
+        )
+        return self.client
 
     def get_async_client(self) -> AsyncQdrantClient:
-        return AsyncQdrantClient(url=self.url, port=self.port)
+        if hasattr(self, "client"):
+            return self.client
+
+        self.client = AsyncQdrantClient(
+            url=self.url,
+            port=self.port,
+            https=self.https,
+            api_key=os.getenv(self.api_key_env_name) if self.api_key_env_name else None,
+            host=self.host,
+            grpc_port=self.grpc_port,
+            grpc_options=self.grpc_options,
+            auth_token_provider=self.auth_token_provider,
+        )
+        return self.client
 
     def _glob(self, client: QdrantClient) -> list[str]:
         return [


### PR DESCRIPTION
### Deprecate unnecessary function
- deprecate automatic collection separation because it's effectiveness is so limited and management of vector db is hard.
- remove `_glob` and `_aglob` method from abstract class due to the deprecation of automatic collection separation, so those are also removed from each client modules.

### Rename methods
- `_delete` -> `_delete_collection`
- `delete` -> `delete_collection`
- `_adelete` -> `_adelete_collection`
- `adelete` -> `adelete_collection`

### Change the interface of some methods of vector db module for supporting more function of each client
- `create_collection` params of each cleint are now acceptable when instantiating CollectionModule.
- we can pass `upsert` params of each client as the variable length arguments of `run()` or `arun()` of CollectionModule while we can pass `query` or `search` params of each client as the variable length arguments of `run()` or `arun()` of RetrievalModule.

### Change the interface of `_upsert` method in abstract class so apply that to base class and each client module
- `_upsert` and `_aupsert` method now includes documents argument.

### Add abstract methods
- Add `_delete_record` for local and remote client and `_adelete_record` for remote client in abstract class. User can access this method via `delete_record` and `adelete_record` method of client modules.

### Add retry process for upsert because sometimes APIConnectionError during upserting
- This retry process is applied when running `run` and `arun` method of CollectionModule.

### Support chromadb again
- `database/chroma.py`