### PR TITLE
System prompt as a constructor argument and tweak way to init conversation

### DIFF
--- a/src/langrila/gemini/llm/chat.py
+++ b/src/langrila/gemini/llm/chat.py
@@ -26,6 +26,7 @@ class GeminiChatCoreModule(BaseChatModule):
         max_tokens: int = 2048,
         json_mode: bool = False,
         timeout: int = 60,
+        system_instruction: str | None = None,
     ):
         self.api_key_env_name = api_key_env_name
         self.model_name = model_name
@@ -42,9 +43,12 @@ class GeminiChatCoreModule(BaseChatModule):
         self.request_options = RequestOptions(
             timeout=timeout,
         )
+        self.system_instruction = system_instruction
 
     def run(self, messages: list[dict[str, str]]) -> CompletionResults:
-        model = get_model(self.model_name, self.api_key_env_name)
+        model = get_model(
+            self.model_name, self.api_key_env_name, system_instruction=self.system_instruction
+        )
         response = model.generate_content(contents=messages, request_options=self.request_options)
         content = response.candidates[0].content
         return CompletionResults(
@@ -57,7 +61,9 @@ class GeminiChatCoreModule(BaseChatModule):
         )
 
     async def arun(self, messages: list[dict[str, str]]) -> CompletionResults:
-        model = get_model(self.model_name, self.api_key_env_name)
+        model = get_model(
+            self.model_name, self.api_key_env_name, system_instruction=self.system_instruction
+        )
         response = await model.generate_content_async(
             contents=messages, request_options=self.request_options
         )
@@ -74,7 +80,9 @@ class GeminiChatCoreModule(BaseChatModule):
     def stream(
         self, messages: list[dict[str, str | list[str]]]
     ) -> Generator[CompletionResults, None, None]:
-        model = get_model(self.model_name, self.api_key_env_name)
+        model = get_model(
+            self.model_name, self.api_key_env_name, system_instruction=self.system_instruction
+        )
         responses = model.generate_content(
             contents=messages, request_options=self.request_options, stream=True
         )
@@ -105,7 +113,9 @@ class GeminiChatCoreModule(BaseChatModule):
     async def astream(
         self, messages: list[dict[str, str]]
     ) -> AsyncGenerator[CompletionResults, None]:
-        model = get_model(self.model_name, self.api_key_env_name)
+        model = get_model(
+            self.model_name, self.api_key_env_name, system_instruction=self.system_instruction
+        )
         responses = await model.generate_content_async(
             contents=messages, request_options=self.request_options, stream=True
         )
@@ -147,6 +157,7 @@ class GeminiChatModule(ChatWrapperModule):
         content_filter: Optional[BaseFilter] = None,
         conversation_memory: Optional[BaseConversationMemory] = None,
         conversation_length_adjuster: Optional[BaseConversationLengthAdjuster] = None,
+        system_instruction: str | None = None,
     ):
         chat_model = GeminiChatCoreModule(
             api_key_env_name=api_key_env_name,
@@ -154,6 +165,7 @@ class GeminiChatModule(ChatWrapperModule):
             max_tokens=max_tokens,
             json_mode=json_mode,
             timeout=timeout,
+            system_instruction=system_instruction,
         )
 
         super().__init__(

--- a/src/langrila/llm_wrapper.py
+++ b/src/langrila/llm_wrapper.py
@@ -27,6 +27,7 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         self.conversation_memory = conversation_memory
         self.content_filter = content_filter
         self.conversation_length_adjuster = conversation_length_adjuster
+        self._INIT_STATUS = False
 
     @abstractmethod
     def _get_client_message_type(self) -> type[BaseMessage]:
@@ -40,6 +41,8 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         **kwargs,
     ) -> CompletionResults:
         Message = self._get_client_message_type()
+        self._init_conversation_memory(init_conversation=init_conversation)
+
         messages = self.load_conversation()
 
         if isinstance(init_conversation, list) and len(messages) == 0:
@@ -74,6 +77,8 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         **kwargs,
     ) -> CompletionResults:
         Message = self._get_client_message_type()
+        self._init_conversation_memory(init_conversation=init_conversation)
+
         messages = self.load_conversation()
 
         if isinstance(init_conversation, list) and len(messages) == 0:
@@ -108,6 +113,8 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         **kwargs,
     ) -> Generator[CompletionResults, None, None]:
         Message = self._get_client_message_type()
+        self._init_conversation_memory(init_conversation=init_conversation)
+
         messages = self.load_conversation()
 
         if isinstance(init_conversation, list) and len(messages) == 0:
@@ -146,6 +153,8 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         **kwargs,
     ) -> AsyncGenerator[CompletionResults, None]:
         Message = self._get_client_message_type()
+        self._init_conversation_memory(init_conversation=init_conversation)
+
         messages = self.load_conversation()
 
         if isinstance(init_conversation, list) and len(messages) == 0:
@@ -188,6 +197,7 @@ class FunctionCallingWrapperModule(ABC, ConversationMixin, FilterMixin):
         self.conversation_memory = conversation_memory
         self.content_filter = content_filter
         self.conversation_length_adjuster = conversation_length_adjuster
+        self._INIT_STATUS = False
 
     @abstractmethod
     def _get_client_message_type(self) -> type[BaseMessage]:
@@ -200,6 +210,8 @@ class FunctionCallingWrapperModule(ABC, ConversationMixin, FilterMixin):
         **kwargs,
     ) -> FunctionCallingResults:
         Message = self._get_client_message_type()
+        self._init_conversation_memory(init_conversation=init_conversation)
+
         messages = self.load_conversation()
 
         if isinstance(init_conversation, list) and len(messages) == 0:
@@ -239,6 +251,8 @@ class FunctionCallingWrapperModule(ABC, ConversationMixin, FilterMixin):
         **kwargs,
     ) -> FunctionCallingResults:
         Message = self._get_client_message_type()
+        self._init_conversation_memory(init_conversation=init_conversation)
+
         messages = self.load_conversation()
 
         if isinstance(init_conversation, list) and len(messages) == 0:

--- a/src/langrila/mixin.py
+++ b/src/langrila/mixin.py
@@ -1,3 +1,8 @@
+from typing import Any
+
+import numpy as np
+
+
 class ConversationMixin:
     def load_conversation(self) -> list[dict[str, str]]:
         if self.conversation_memory is not None:
@@ -9,6 +14,24 @@ class ConversationMixin:
 
     def save_conversation(self, messages: list[dict[str, str]]) -> None:
         self.conversation_memory.store(messages)
+
+    def _init_conversation_memory(self, init_conversation: list[dict[str, Any]] | None) -> None:
+        if (
+            self.conversation_memory
+            and init_conversation
+            and (
+                not hasattr(self, "_INIT_STATUS")
+                or (hasattr(self, "_INIT_STATUS") and not self._INIT_STATUS)
+            )
+        ):
+            memory: list[dict[str, Any]] = self.conversation_memory.load()
+
+            # check if init_conversation is already stored in conversation_memory
+            # if not, add it to the conversation_memory
+            if not np.isin(init_conversation, memory).all():
+                memory.extend(init_conversation)
+                self.conversation_memory.store(memory)
+                self._INIT_STATUS = True
 
 
 class FilterMixin:


### PR DESCRIPTION
- Unified interface to pass system instruction toChatGPT and Gemini.
- For chatgpt, system prompt must be in the conversation history explicitly, so implemented format process to pass system prompt in both cases conversation_memory is used or not.
- Updated way to pass init_conversation when conversation_memory is used to avoid duplication of init_conversation in conversation history.