### PR TITLE
Hide system instruction from conversation memory for OpenAI module

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,7 @@ response.model_dump()
 
 >>> {'message': {'role': 'assistant', 'content': 'Yes.'},
  'usage': {'prompt_tokens': 36, 'completion_tokens': 2},
- 'prompt': [{'role': 'system',
-   'content': 'You must answer any questions only with yes or no.'},
-  {'role': 'user',
+ 'prompt': [{'role': 'user',
    'content': 'Please give me only one advice to improve the quality of my sleep.'}]}
 ```
 

--- a/src/langrila/llm_wrapper.py
+++ b/src/langrila/llm_wrapper.py
@@ -21,12 +21,10 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         chat_model: BaseChatModule,
         conversation_memory: Optional[BaseConversationMemory] = None,
         content_filter: Optional[BaseFilter] = None,
-        conversation_length_adjuster: Optional[BaseConversationLengthAdjuster] = None,
     ):
         self.chat_model = chat_model
         self.conversation_memory = conversation_memory
         self.content_filter = content_filter
-        self.conversation_length_adjuster = conversation_length_adjuster
         self._INIT_STATUS = False
 
     @abstractmethod
@@ -53,11 +51,7 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         if self.content_filter is not None:
             messages = self.content_filter.apply(messages)
 
-        if self.conversation_length_adjuster is not None:
-            messages_adjusted = self.conversation_length_adjuster.run(messages)
-            response = self.chat_model.run(messages_adjusted)
-        else:
-            response = self.chat_model.run(messages)
+        response = self.chat_model.run(messages)
 
         if self.content_filter is not None:
             response.message = self.restore_content_filter([response.message])[0]
@@ -89,11 +83,7 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         if self.content_filter is not None:
             messages = self.content_filter.apply(messages)
 
-        if self.conversation_length_adjuster is not None:
-            messages_adjusted = self.conversation_length_adjuster.run(messages)
-            response = await self.chat_model.arun(messages_adjusted)
-        else:
-            response = await self.chat_model.arun(messages)
+        response = await self.chat_model.arun(messages)
 
         if self.content_filter is not None:
             response.message = self.restore_content_filter([response.message])[0]
@@ -125,11 +115,7 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         if self.content_filter is not None:
             messages = self.content_filter.apply(messages)
 
-        if self.conversation_length_adjuster is not None:
-            messages_adjusted = self.conversation_length_adjuster.run(messages)
-            response = self.chat_model.stream(messages_adjusted)
-        else:
-            response = self.chat_model.stream(messages)
+        response = self.chat_model.stream(messages)
 
         for chunk in response:
             if isinstance(chunk, CompletionResults):
@@ -165,11 +151,7 @@ class ChatWrapperModule(ABC, ConversationMixin, FilterMixin):
         if self.content_filter is not None:
             messages = self.content_filter.apply(messages)
 
-        if self.conversation_length_adjuster is not None:
-            messages_adjusted = self.conversation_length_adjuster.run(messages)
-            response = self.chat_model.astream(messages_adjusted)
-        else:
-            response = self.chat_model.astream(messages)
+        response = self.chat_model.astream(messages)
 
         async for chunk in response:
             if isinstance(chunk, CompletionResults):
@@ -191,12 +173,10 @@ class FunctionCallingWrapperModule(ABC, ConversationMixin, FilterMixin):
         function_calling_model: BaseFunctionCallingModule,
         conversation_memory: Optional[BaseConversationMemory] = None,
         content_filter: Optional[BaseFilter] = None,
-        conversation_length_adjuster: Optional[BaseConversationLengthAdjuster] = None,
     ):
         self.function_calling_model = function_calling_model
         self.conversation_memory = conversation_memory
         self.content_filter = content_filter
-        self.conversation_length_adjuster = conversation_length_adjuster
         self._INIT_STATUS = False
 
     @abstractmethod
@@ -222,11 +202,7 @@ class FunctionCallingWrapperModule(ABC, ConversationMixin, FilterMixin):
         if self.content_filter is not None:
             messages = self.apply_content_filter(messages)
 
-        if self.conversation_length_adjuster is not None:
-            messages_adjusted = self.conversation_length_adjuster.run(messages)
-            response = self.function_calling_model.run(messages_adjusted, **kwargs)
-        else:
-            response = self.function_calling_model.run(messages, **kwargs)
+        response = self.function_calling_model.run(messages, **kwargs)
 
         if self.content_filter is not None:
             for i, _ in enumerate(response.results):
@@ -263,11 +239,7 @@ class FunctionCallingWrapperModule(ABC, ConversationMixin, FilterMixin):
         if self.content_filter is not None:
             messages = self.apply_content_filter(messages)
 
-        if self.conversation_length_adjuster is not None:
-            messages_adjusted = self.conversation_length_adjuster.run(messages)
-            response = await self.function_calling_model.arun(messages_adjusted, **kwargs)
-        else:
-            response = await self.function_calling_model.arun(messages, **kwargs)
+        response = await self.function_calling_model.arun(messages, **kwargs)
 
         if self.content_filter is not None:
             for i, _ in enumerate(response.results):


### PR DESCRIPTION
For gemini, api accepts system instruction when instantiate client and system instruction is hidden from conversation memory. For openai api, we must include system instruction in messages explicitly, but it occurs additional work when we want to reuse conversation history except system instruction. Obviously it is more flexible that we can pass system instruction just before generating response and hide it from conversation memory