### PR TITLE
Impl SQLiteMetadataFilter

### DIFF
--- a/src/langrila/filter/metadata/__init__.py
+++ b/src/langrila/filter/metadata/__init__.py
@@ -1,0 +1,1 @@
+from .sqlite import SQLiteMetadataFilter

--- a/src/langrila/filter/metadata/sqlite.py
+++ b/src/langrila/filter/metadata/sqlite.py
@@ -1,0 +1,140 @@
+import re
+from typing import Any
+
+from ...base import BaseMetadataFilter
+
+
+class SQLiteMetadataFilter(BaseMetadataFilter):
+    """
+    Apply a WHERE clause in SQLite format to a metadata dictionary.
+    """
+
+    def __init__(self, where: str):
+        where = re.sub("%", "", where)
+        self.conditions: list[tuple[Any, str, Any]] = self._parse_where_clause(where_clause=where)
+
+    def _parse_value(self, value):
+        value = value.strip()
+        if value.startswith("'") and value.endswith("'"):
+            value = value[1:-1]  # Remove the single quotes
+        elif value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]  # Remove the double quotes
+        return value
+
+    def _parse_in_clause(self, field, values):
+        values = values.strip()[1:-1]  # Remove the surrounding parentheses
+        value_list = [self._parse_value(v.strip()) for v in values.split(",")]
+        return [field, "IN", value_list]
+
+    def _parse_where_clause(self, where_clause: str) -> list[tuple[Any, str, Any]]:
+        conditions = []
+        stack = []
+
+        # Separate IN clause to distinguish brackets in IN clause from other brackets
+        in_clauses = re.findall(r"\w+\s+IN\s+\([^)]*\)", where_clause, flags=re.IGNORECASE)
+        for in_clause in in_clauses:
+            where_clause = where_clause.replace(in_clause, f"IN_CLAUSE_{len(stack)}")
+            stack.append(in_clause)
+
+        tokens = re.split(r"(\(|\)|\s+AND\s+|\s+OR\s+)", where_clause, flags=re.IGNORECASE)
+        tokens = [token.strip() for token in tokens if token.strip()]
+
+        for token in tokens:
+            if token == "(":
+                stack.append(conditions)
+                conditions = []
+            elif token == ")":
+                last_conditions = conditions
+                conditions = stack.pop()
+                conditions.append(last_conditions)
+            elif token.upper() in ["AND", "OR"]:
+                conditions.append(token.upper())
+            elif token.startswith("IN_CLAUSE_"):
+                index = int(token.split("_")[-1])
+                in_clause = stack[index]
+                in_match = re.match(r"(\w+)\s+IN\s+(\(.+\))", in_clause, re.IGNORECASE)
+                if in_match:
+                    field, values = in_match.groups()
+                    conditions.append(self._parse_in_clause(field, values))
+            else:
+                match = re.match(r"(\w+)\s*(>=|<=|!=|=|>|<|LIKE)\s*(.+)", token, re.IGNORECASE)
+                if match:
+                    field, operator, value = match.groups()
+                    value = self._parse_value(value)
+                    conditions.append([field, operator.upper(), value])
+
+        return conditions
+
+    def _apply_conditions(
+        self, item: dict[str, Any], conditions: list[tuple[Any, str, Any]]
+    ) -> bool:
+        stack = []
+        for condition in conditions:
+            if condition in ["AND", "OR"]:
+                stack.append(condition)
+            else:
+                if isinstance(condition, list) and ("AND" in condition or "OR" in condition):
+                    stack.append(self._apply_conditions(item, condition))
+                else:
+                    field: str
+                    operator: str
+                    value: str
+                    field, operator, value = condition
+                    item_value = item.get(field)
+
+                    if item_value is None:
+                        result = False
+                    else:
+                        if operator == "=":
+                            result = item_value == value
+                        elif operator == "!=":
+                            result = item_value != value
+                        elif operator == ">":
+                            if value.isdigit():
+                                result = float(item_value) > float(value)
+                            else:
+                                result = item_value > value
+                        elif operator == "<":
+                            if value.isdigit():
+                                result = float(item_value) < float(value)
+                            else:
+                                result = item_value < value
+                        elif operator == ">=":
+                            if value.isdigit():
+                                result = float(item_value) >= float(value)
+                            else:
+                                result = item_value >= value
+                        elif operator == "<=":
+                            if value.isdigit():
+                                result = float(item_value) <= float(value)
+                            else:
+                                result = item_value <= value
+                        elif operator == "LIKE":
+                            pattern_split = re.compile(r",|、|\s|　")
+                            values = pattern_split.split(value)
+                            result = any([bool(re.search(v, item_value)) for v in values if v])
+                        elif operator == "IN":
+                            pattern_split = re.compile(r",|、|\s|　")
+                            item_values = pattern_split.split(item_value)
+                            value = set(value)
+                            result = any([v in value for v in item_values])
+
+                    stack.append(result)
+
+        # Evaluate the condition stack
+        while len(stack) > 1:
+            left = stack.pop(0)
+            operator = stack.pop(0)
+            right = stack.pop(0)
+            if operator == "AND":
+                stack.insert(0, left and right)
+            elif operator == "OR":
+                stack.insert(0, left or right)
+
+        if stack:
+            return stack[0]
+        else:
+            return False
+
+    def run(self, metadata: dict[str, Any]) -> bool:
+        return self._apply_conditions(metadata, self.conditions)

--- a/src/langrila/filter/metadata/sqlite.py
+++ b/src/langrila/filter/metadata/sqlite.py
@@ -74,7 +74,7 @@ class SQLiteMetadataFilter(BaseMetadataFilter):
                     field, values = not_in_match.groups()
                     conditions.append(self._parse_not_in_clause(field, values))
             else:
-                match = re.match(r"(\w+)\s*(>=|<=|!=|=|>|<|LIKE)\s*(.+)", token, re.IGNORECASE)
+                match = re.match(r"(\w+)\s*(>=|<=|!=|<>|=|>|<|LIKE)\s*(.+)", token, re.IGNORECASE)
                 if match:
                     field, operator, value = match.groups()
                     value = self._parse_value(value)
@@ -104,7 +104,7 @@ class SQLiteMetadataFilter(BaseMetadataFilter):
                     else:
                         if operator == "=":
                             result = item_value == value
-                        elif operator == "!=":
+                        elif operator == "!=" or operator == "<>":
                             result = item_value != value
                         elif operator == ">":
                             if value.isdigit():


### PR DESCRIPTION
Given a dictionary metadata like this:

```python
dummy_data = [{'author': 'Bob', 'published_date': '2008-06-27'},
 {'author': 'John', 'published_date': '2014-08-26'},
 {'author': 'Alice, Bob', 'published_date': '2022-01-30'},
 {'author': 'John', 'published_date': '2009-11-30'},
...
```

`SQLiteMetadataFilter` can apply a WHERE clause in SQLite format to this metadata.

```python
from langrila.filter.metadata import SQLiteMetadataFilter

where_clause = "author IN ('John','Alice') AND (published_date < '2010-01-01' OR published_date >= '2024-01-01')"

sqlite_filter = SQLiteMetadataFilter(where=where_clause)
[m for m in dummy_data if sqlite_filter.run(m)]
```

Then we can see this result:

```python
[{'author': 'John', 'published_date': '2009-11-30'},
 {'author': 'John, Alice', 'published_date': '2006-04-12'},
 {'author': 'Alice, Bob', 'published_date': '2007-10-24'},
 {'author': 'John, Bob', 'published_date': '2001-01-26'},
 {'author': 'John, Alice', 'published_date': '2003-10-15'},
 {'author': 'John, Bob', 'published_date': '2024-11-30'},
 {'author': 'John, Alice, Bob', 'published_date': '2003-04-25'},
 {'author': 'John, Bob', 'published_date': '2008-09-11'},
 {'author': 'Alice, Bob', 'published_date': '2009-03-06'},
 {'author': 'Alice', 'published_date': '2009-12-17'},
 {'author': 'John, Alice', 'published_date': '2000-07-02'},
 {'author': 'Alice, Bob', 'published_date': '2003-01-14'},
 {'author': 'John, Alice', 'published_date': '2024-04-22'},
...
```

Here is supported operators:
- `=`
- `==`
- `>`
- `>=`
- `<`
- `<=`
- `<>`
- `IS`
- `IS NOT`
- `IN`
- `NOT IN`
- `LIKE`
- `AND`
- `OR`