### PR TITLE
Fix the way to handle init_conversation when tool is called

### DIFF
--- a/src/langrila/claude/assembly.py
+++ b/src/langrila/claude/assembly.py
@@ -167,6 +167,9 @@ class ClaudeFunctionalChat(BaseAssembly):
                 _prompt = [c for r in response_function_calling.results for c in r.content]
                 if _prompt:
                     prompt = _prompt
+                    init_conversation = (
+                        None  # if tool is used, init_conversation is stored in the memory
+                    )
 
                 response_function_calling: FunctionCallingResults = self.function_calling.run(
                     prompt, init_conversation=init_conversation
@@ -229,6 +232,9 @@ class ClaudeFunctionalChat(BaseAssembly):
                 _prompt = [c for r in response_function_calling.results for c in r.content]
                 if _prompt:
                     prompt = _prompt
+                    init_conversation = (
+                        None  # if tool is used, init_conversation is stored in the memory
+                    )
 
                 response_function_calling: FunctionCallingResults = (
                     await self.function_calling.arun(prompt, init_conversation=init_conversation)

--- a/src/langrila/gemini/assembly.py
+++ b/src/langrila/gemini/assembly.py
@@ -146,6 +146,9 @@ class GeminiFunctionalChat(BaseAssembly):
             _prompt = [c for r in response_function_calling.results for c in r.content]
             if _prompt:
                 prompt = _prompt
+                init_conversation = (
+                    None  # if tool is used, init_conversation is stored in the memory
+                )
 
         response_chat: CompletionResults = self.chat.run(
             prompt, init_conversation=init_conversation, n_results=n_results
@@ -184,6 +187,9 @@ class GeminiFunctionalChat(BaseAssembly):
             _prompt = [c for r in response_function_calling.results for c in r.content]
             if _prompt:
                 prompt = _prompt
+                init_conversation = (
+                    None  # if tool is used, init_conversation is stored in the memory
+                )
 
         response_chat: CompletionResults = await self.chat.arun(
             prompt, init_conversation=init_conversation, n_results=n_results
@@ -212,6 +218,9 @@ class GeminiFunctionalChat(BaseAssembly):
             _prompt = [c for r in response_function_calling.results for c in r.content]
             if _prompt:
                 prompt = _prompt
+                init_conversation = (
+                    None  # if tool is used, init_conversation is stored in the memory
+                )
 
         response_chat: CompletionResults = self.chat.stream(
             prompt, init_conversation=init_conversation
@@ -240,6 +249,9 @@ class GeminiFunctionalChat(BaseAssembly):
             _prompt = [c for r in response_function_calling.results for c in r.content]
             if _prompt:
                 prompt = _prompt
+                init_conversation = (
+                    None  # if tool is used, init_conversation is stored in the memory
+                )
 
         response_chat: CompletionResults = self.chat.astream(
             prompt, init_conversation=init_conversation

--- a/src/langrila/openai/assembly.py
+++ b/src/langrila/openai/assembly.py
@@ -139,6 +139,7 @@ class OpenAIFunctionalChat(BaseAssembly):
             prompt=prompt,
             gather_prompts=False if tool_choice is not None else True,
             n_results=n_results,
+            init_conversation=init_conversation,
         )
 
         self._clear_memory()
@@ -185,6 +186,7 @@ class OpenAIFunctionalChat(BaseAssembly):
             prompt=prompt,
             gather_prompts=False if tool_choice is not None else True,
             n_results=n_results,
+            init_conversation=init_conversation,
         )
 
         self._clear_memory()
@@ -220,6 +222,7 @@ class OpenAIFunctionalChat(BaseAssembly):
         response_chat: CompletionResults = self.chat.stream(
             prompt=prompt,
             gather_prompts=False if tool_choice is not None else True,
+            init_conversation=init_conversation,
         )
 
         self._clear_memory()
@@ -255,6 +258,7 @@ class OpenAIFunctionalChat(BaseAssembly):
         response_chat: CompletionResults = self.chat.astream(
             prompt=prompt,
             gather_prompts=False if tool_choice is not None else True,
+            init_conversation=init_conversation,
         )
 
         self._clear_memory()

--- a/src/langrila/openai/assembly.py
+++ b/src/langrila/openai/assembly.py
@@ -131,6 +131,9 @@ class OpenAIFunctionalChat(BaseAssembly):
             ]
             if _prompt:
                 prompt = _prompt
+                init_conversation = (
+                    None  # if tool is used, init_conversation is stored in the memory
+                )
 
         response_chat: CompletionResults = self.chat.run(
             prompt=prompt,
@@ -174,6 +177,9 @@ class OpenAIFunctionalChat(BaseAssembly):
             ]
             if _prompt:
                 prompt = _prompt
+                init_conversation = (
+                    None  # if tool is used, init_conversation is stored in the memory
+                )
 
         response_chat: CompletionResults = await self.chat.arun(
             prompt=prompt,
@@ -207,6 +213,9 @@ class OpenAIFunctionalChat(BaseAssembly):
             ]
             if _prompt:
                 prompt = _prompt
+                init_conversation = (
+                    None  # if tool is used, init_conversation is stored in the memory
+                )
 
         response_chat: CompletionResults = self.chat.stream(
             prompt=prompt,
@@ -239,6 +248,9 @@ class OpenAIFunctionalChat(BaseAssembly):
             ]
             if _prompt:
                 prompt = _prompt
+                init_conversation = (
+                    None  # if tool is used, init_conversation is stored in the memory
+                )
 
         response_chat: CompletionResults = self.chat.astream(
             prompt=prompt,


### PR DESCRIPTION
Fix the following points:
- If tool is called, init_conversation is replaced with None to avoid duplication. Init conversation is stored into conversation_memory at the first function calling step if tool is called.
- Add missing init_conversation arguments in OpenAIFunctionalChat.