### PR TITLE
Adding capability of pydantic tool definition

### DIFF
--- a/src/langrila/base.py
+++ b/src/langrila/base.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
+from inspect import isfunction, ismethod
 from pathlib import Path
-from typing import Any, AsyncGenerator, Generator
+from typing import Any, AsyncGenerator, Callable, Generator
 
 from PIL import Image
+from pydantic import BaseModel
 
 from .message_content import (
     ApplicationFileContent,
@@ -22,7 +24,7 @@ from .result import (
     ToolOutput,
 )
 from .types import RoleType
-from .utils import decode_image
+from .utils import decode_image, model2func
 
 
 class BaseChatModule(ABC):
@@ -49,6 +51,9 @@ class BaseFunctionCallingModule(ABC):
 
     async def arun(self, messages: list[dict[str, str]]) -> FunctionCallingResults:
         raise NotImplementedError
+
+    def _set_runnable_tools_dict(self, tools: list[Callable | BaseModel]) -> dict[str, callable]:
+        return {f.__name__: f if (isfunction(f) or ismethod(f)) else model2func(f) for f in tools}
 
 
 class BaseEmbeddingModule(ABC):

--- a/src/langrila/claude/llm/function_calling.py
+++ b/src/langrila/claude/llm/function_calling.py
@@ -25,6 +25,7 @@ from ...base import (
     BaseConversationLengthAdjuster,
     BaseConversationMemory,
     BaseFilter,
+    BaseFunctionCallingModule,
     BaseMessage,
 )
 from ...llm_wrapper import FunctionCallingWrapperModule
@@ -37,7 +38,7 @@ from ..message import ClaudeMessage
 from ..tools import ClaudeToolConfig
 
 
-class AnthropicFunctionCallingCoreModule(BaseChatModule):
+class AnthropicFunctionCallingCoreModule(BaseFunctionCallingModule):
     def __init__(
         self,
         model_name: str,
@@ -103,7 +104,7 @@ class AnthropicFunctionCallingCoreModule(BaseChatModule):
         ClientToolConfig = self._get_client_tool_type()
         client_tool_configs = ClientToolConfig.from_universal_configs(tool_configs)
 
-        self.tools = {f.__name__: f for f in tools}
+        self.tools = self._set_runnable_tools_dict(tools)
         self.tool_configs = [f.format() for f in client_tool_configs]
 
     def _get_client_tool_type(self) -> ClaudeToolConfig:

--- a/src/langrila/gemini/llm/function_calling.py
+++ b/src/langrila/gemini/llm/function_calling.py
@@ -10,6 +10,7 @@ from ...base import (
     BaseConversationLengthAdjuster,
     BaseConversationMemory,
     BaseFilter,
+    BaseFunctionCallingModule,
     BaseMessage,
 )
 from ...llm_wrapper import FunctionCallingWrapperModule
@@ -26,7 +27,7 @@ from ..gemini_utils import (
 )
 
 
-class GeminiFunctionCallingCoreModule(BaseChatModule):
+class GeminiFunctionCallingCoreModule(BaseFunctionCallingModule):
     def __init__(
         self,
         model_name: str,
@@ -91,7 +92,7 @@ class GeminiFunctionCallingCoreModule(BaseChatModule):
 
         ClientToolConfig = self._get_client_tool_config_type(api_type)
         client_tool_configs = ClientToolConfig.from_universal_configs(tool_configs)
-        self.tools = {func.__name__: func for func in tools}
+        self.tools = self._set_runnable_tools_dict(tools)
 
         tool_cls = get_tool_cls(api_type=api_type)
         function_declarations = [config.format() for config in client_tool_configs]

--- a/src/langrila/openai/llm/function_calling.py
+++ b/src/langrila/openai/llm/function_calling.py
@@ -3,6 +3,7 @@ import json
 from typing import Callable, Optional
 
 from openai._types import NOT_GIVEN, NotGiven
+from pydantic import BaseModel
 
 from ...base import (
     BaseConversationLengthAdjuster,
@@ -14,6 +15,7 @@ from ...base import (
 from ...llm_wrapper import FunctionCallingWrapperModule
 from ...result import FunctionCallingResults, ToolCallResponse, ToolOutput
 from ...usage import TokenCounter, Usage
+from ...utils import model2func
 from ..conversation_adjuster.truncate import OldConversationTruncationModule
 from ..message import OpenAIMessage
 from ..model_config import (
@@ -70,7 +72,7 @@ class FunctionCallingCoreModule(BaseFunctionCallingModule):
         self.temperature = temperature
         self.user = user
 
-        self.tools = {f.__name__: f for f in tools}
+        self.tools = self._set_runnable_tools_dict(tools)
 
         _tool_names_from_config = {f.name for f in tool_configs}
         assert (

--- a/src/langrila/utils.py
+++ b/src/langrila/utils.py
@@ -2,10 +2,12 @@ import base64
 import io
 import random
 import string
+from functools import partial
 from typing import Any, Generator, Iterable
 
 import numpy as np
 from PIL import Image
+from pydantic import BaseModel
 
 
 def make_batch(
@@ -74,3 +76,10 @@ def decode_image(image_encoded: str, as_utf8: bool = False) -> Image.Image:
 
 def generate_dummy_call_id(n: int) -> str:
     return "".join(random.choices(string.ascii_letters + string.digits, k=n))
+
+
+def model2func(model: BaseModel):
+    def run_model(model: BaseModel, **kwargs):
+        return model(**kwargs).run()
+
+    return partial(run_model, model=model)


### PR DESCRIPTION
Tool definition in langrila uses `ToolProperty`, `ToolParameter` and `ToolConfig` directly. Now we can also define tool as a pydantic model like this: 

```python
from enum import Enum
from typing import Literal

from pydantic import BaseModel, Field


class PowerDiscoBall(BaseModel):
    """Powers the spinning disco ball."""

    power: bool = Field(description="Boolean to spin disco ball.")

    def run(self) -> str:
        return f"Disco ball is {'spinning!' if self.power else 'stopped.'}"


class DimLights(BaseModel):
    """Dim the lights."""

    brightness: float = Field(description="The brightness of the lights, 0.0 is off, 1.0 is full.")

    def run(self) -> str:
        return f"Lights are now set to {self.brightness}"


class BPM(Enum):
    """The beats per minute of the music."""

    SLOW = "60"
    MEDIUM = "120"
    FAST = "180"


class StartMusic(BaseModel):
    """Play some music matching the specified parameters."""

    energetic: bool = Field(description="Whether the music is energetic or not.")
    loud: bool = Field(description="Whether the music is loud or not.")
    bpm: BPM = Field(description="The beats per minute of the music.")
    # bpm: Literal["60", "120", "180"] = Field(..., description="The beats per minute of the music.") # This also works

    def run(self) -> str:
        return f"Starting music! {self.energetic=} {self.loud=}, {self.bpm=}"
```

Then these tools could be input to ClientFunctionCallingModule and ClientFunctionalChat.

```python
# Convert to ToolConfig
tools = [PowerDiscoBall, StartMusic, DimLights]
tool_configs_pydantic = [ToolConfig.from_pydantic(tool) for tool in tools]

chat_openai = OpenAIFunctionalChat(
    api_key_env_name="API_KEY",
    model_name="gpt-4o-mini-2024-07-18",
    tools=tools,
    tool_configs=tool_configs_pydantic,
)
```