### PR TITLE
Add max_output_tokens and update model config of OpenAI API

### DIFF
--- a/src/langrila/openai/model_config.py
+++ b/src/langrila/openai/model_config.py
@@ -2,11 +2,6 @@ _TOKENS_PER_TILE = 170
 _TILE_SIZE = 512
 
 _OLDER_MODEL_CONFIG = {
-    "gpt-4-0314": {
-        "max_tokens": 8192,
-        "prompt_cost_per_token": 0.00003,
-        "completion_cost_per_token": 0.00006,
-    },
     "gpt-4-0613": {
         "max_tokens": 8192,
         "prompt_cost_per_token": 0.00003,

--- a/src/langrila/openai/model_config.py
+++ b/src/langrila/openai/model_config.py
@@ -121,6 +121,7 @@ MODEL_POINT = {
 }
 
 _MODEL_POINT_CONFIG = {
+    "gpt-4o-mini": MODEL_CONFIG[MODEL_POINT["gpt-4o-mini"]],
     "gpt-4o": MODEL_CONFIG[MODEL_POINT["gpt-4o"]],
     "gpt-4-turbo": MODEL_CONFIG[MODEL_POINT["gpt-4-turbo"]],
     "gpt-4": MODEL_CONFIG[MODEL_POINT["gpt-4"]],

--- a/src/langrila/openai/model_config.py
+++ b/src/langrila/openai/model_config.py
@@ -82,21 +82,6 @@ _NEWER_MODEL_CONFIG = {
     },
 }
 
-MODEL_POINT = {
-    "gpt-4o-mini": "gpt-4o-mini-2024-07-18",
-    "gpt-4o": "gpt-4o-2024-05-13",
-    "gpt-4-turbo": "gpt-4-turbo-2024-04-09",
-    "gpt-4-turbo-preview": "gpt-4-0125-preview",
-    "gpt-4": "gpt-4-0613",
-    "gpt-4-32k": "gpt-4-32k-0613",
-    "gpt-4-128k": "gpt-4-1106-preview",
-    "gpt-4-vision": "gpt-4-vision-preview",
-    "gpt-4-vision-1106-preview": "gpt-4-vision-preview",
-    "gpt-3.5-turbo": "gpt-3.5-turbo-0125",
-    "gpt-3.5-turbo-16k": "gpt-3.5-turbo-16k-0613",
-}
-
-
 _NEWER_EMBEDDING_CONFIG = {
     "text-embedding-3-small": {
         "max_tokens": 8192,
@@ -123,6 +108,17 @@ EMBEDDING_CONFIG.update(_NEWER_EMBEDDING_CONFIG)
 MODEL_CONFIG = {}
 MODEL_CONFIG.update(_OLDER_MODEL_CONFIG)
 MODEL_CONFIG.update(_NEWER_MODEL_CONFIG)
+
+MODEL_POINT = {
+    "gpt-4o-mini": "gpt-4o-mini-2024-07-18",
+    "gpt-4o": "gpt-4o-2024-05-13",
+    "gpt-4-turbo": "gpt-4-turbo-2024-04-09",
+    "gpt-4": "gpt-4-0613",
+    "gpt-4-32k": "gpt-4-32k-0613",
+    "gpt-4-vision": "gpt-4-vision-preview",
+    "gpt-3.5-turbo": "gpt-3.5-turbo-0125",
+    "gpt-3.5-turbo-16k": "gpt-3.5-turbo-16k-0613",
+}
 
 _MODEL_POINT_CONFIG = {
     "gpt-4o": MODEL_CONFIG[MODEL_POINT["gpt-4o"]],

--- a/src/langrila/openai/model_config.py
+++ b/src/langrila/openai/model_config.py
@@ -4,36 +4,43 @@ _TILE_SIZE = 512
 _OLDER_MODEL_CONFIG = {
     "gpt-4-0613": {
         "max_tokens": 8192,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.00003,
         "completion_cost_per_token": 0.00006,
     },
     "gpt-4-32k-0314": {
         "max_tokens": 32768,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.00006,
         "completion_cost_per_token": 0.00012,
     },
     "gpt-4-32k-0613": {
         "max_tokens": 32768,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.00006,
         "completion_cost_per_token": 0.00012,
     },
     "gpt-3.5-turbo-0301": {
         "max_tokens": 4096,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.0000015,
         "completion_cost_per_token": 0.000002,
     },
     "gpt-3.5-turbo-0613": {
         "max_tokens": 4096,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.0000015,
         "completion_cost_per_token": 0.000002,
     },
     "gpt-3.5-turbo-16k-0613": {
         "max_tokens": 16384,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.000003,
         "completion_cost_per_token": 0.000004,
     },
     "gpt-3.5-turbo-instruct": {
         "max_tokens": 4096,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.0000015,
         "completion_cost_per_token": 0.000002,
     },
@@ -42,41 +49,49 @@ _OLDER_MODEL_CONFIG = {
 _NEWER_MODEL_CONFIG = {
     "gpt-4o-mini-2024-07-18": {
         "max_tokens": 128000,
+        "max_output_tokens": 16384,
         "prompt_cost_per_token": 0.000000150,
         "completion_cost_per_token": 0.00000060,
     },
     "gpt-4o-2024-05-13": {
         "max_tokens": 128000,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.000005,
         "completion_cost_per_token": 0.000015,
     },
     "gpt-4-turbo-2024-04-09": {
         "max_tokens": 128000,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.00001,
         "completion_cost_per_token": 0.00003,
     },
     "gpt-4-0125-preview": {
         "max_tokens": 128000,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.00001,
         "completion_cost_per_token": 0.00003,
     },
     "gpt-4-1106-preview": {
         "max_tokens": 128000,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.00001,
         "completion_cost_per_token": 0.00003,
     },
     "gpt-4-vision-preview": {
         "max_tokens": 128000,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.00001,
         "completion_cost_per_token": 0.00003,
     },
     "gpt-3.5-turbo-0125": {
         "max_tokens": 16384,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.0000005,
         "completion_cost_per_token": 0.0000015,
     },
     "gpt-3.5-turbo-1106": {
         "max_tokens": 16384,
+        "max_output_tokens": 4096,
         "prompt_cost_per_token": 0.000001,
         "completion_cost_per_token": 0.000002,
     },

--- a/src/langrila/openai/model_config.py
+++ b/src/langrila/openai/model_config.py
@@ -126,7 +126,6 @@ _MODEL_POINT_CONFIG = {
     "gpt-4-turbo": MODEL_CONFIG[MODEL_POINT["gpt-4-turbo"]],
     "gpt-4": MODEL_CONFIG[MODEL_POINT["gpt-4"]],
     "gpt-4-32k": MODEL_CONFIG[MODEL_POINT["gpt-4-32k"]],
-    "gpt-4-128k": MODEL_CONFIG[MODEL_POINT["gpt-4-128k"]],
     "gpt-4-vision": MODEL_CONFIG[MODEL_POINT["gpt-4-vision"]],
     "gpt-3.5-turbo": MODEL_CONFIG[MODEL_POINT["gpt-3.5-turbo"]],
     "gpt-3.5-turbo-16k": MODEL_CONFIG[MODEL_POINT["gpt-3.5-turbo-16k"]],


### PR DESCRIPTION
Deprecated
- config of `gpt-4-0314`
- alias of `gpt-4-128k`

New
- Add model config alias for `gpt-4o-mini-2024-07-18`
- Add max_output_tokens to model config