### PR TITLE
Support structured outputs for OpenAI chat completion

### DIFF
--- a/src/langrila/claude/tools.py
+++ b/src/langrila/claude/tools.py
@@ -42,7 +42,7 @@ class ClaudeToolConfig(ToolConfig):
     parameters: ClaudeToolParameter
 
     def format(self):
-        dumped = self.model_dump(exclude=["parameters"])
+        dumped = self.model_dump(exclude=["parameters", "strict"])
         dumped["input_schema"] = self.parameters.format()
         return ToolParam(**dumped)
 

--- a/src/langrila/openai/assembly.py
+++ b/src/langrila/openai/assembly.py
@@ -1,6 +1,7 @@
 from typing import AsyncGenerator, Callable, Generator, Literal
 
 from openai._types import NOT_GIVEN, NotGiven
+from pydantic import BaseModel
 
 from ..base import BaseConversationLengthAdjuster, BaseConversationMemory, BaseFilter
 from ..base_assembly import BaseAssembly
@@ -40,6 +41,7 @@ class OpenAIFunctionalChat(BaseAssembly):
         presence_penalty: float | None | NotGiven = NOT_GIVEN,
         temperature: float | None | NotGiven = NOT_GIVEN,
         user: str | NotGiven = NOT_GIVEN,
+        response_schema: BaseModel | None = None,
     ) -> None:
         super().__init__(conversation_memory=conversation_memory)
 
@@ -67,6 +69,7 @@ class OpenAIFunctionalChat(BaseAssembly):
             presence_penalty=presence_penalty,
             temperature=temperature,
             user=user,
+            response_schema=response_schema,
         )
 
         if tools:

--- a/src/langrila/openai/tools.py
+++ b/src/langrila/openai/tools.py
@@ -55,11 +55,18 @@ class OpenAIToolConfig(ToolConfig):
     type: str = "function"
     description: str
     parameters: OpenAIToolParameter
+    strict: bool | None = None
 
     def format(self):
-        dumped = self.model_dump(exclude=["parameters", "type"])
+        dumped = self.model_dump(exclude=["parameters", "type", "strict"])
         dumped["parameters"] = self.parameters.format()
-        return {"type": self.type, self.type: dumped}
+
+        output = {"type": self.type, self.type: dumped}
+
+        if self.strict is not None:
+            output["strict"] = self.strict
+
+        return output
 
     @field_validator("type")
     def check_type_value(cls, v):

--- a/src/langrila/tools.py
+++ b/src/langrila/tools.py
@@ -20,9 +20,10 @@ class ToolConfig(BaseModel):
     name: str
     description: str
     parameters: ToolParameter
+    strict: bool | None = None
 
     @classmethod
-    def from_pydantic(cls, model: BaseModel) -> "ToolConfig":
+    def from_pydantic(cls, model: BaseModel, **kwargs) -> "ToolConfig":
         configs = {}
         params = {}
 
@@ -51,4 +52,4 @@ class ToolConfig(BaseModel):
         params["properties"] = props
         configs["parameters"] = params
 
-        return cls(**configs)
+        return cls(**configs, **kwargs)


### PR DESCRIPTION
We can specify `response_schema` argument to use structuered outputs.

Define output schema:
```python
from pydantic import BaseModel


class Step(BaseModel):
    explanation: str
    output: str


class MathReasoning(BaseModel):
    steps: list[Step]
    final_answer: str
```

Specify `response_schema` argument (need `json_mode` as well): 
```python
chat_openai = OpenAIFunctionalChat(
    api_key_env_name="API_KEY",
    model_name="gpt-4o-2024-08-06",
    api_type="openai",
    json_mode=True,
    response_schema=MathReasoning,
    system_instruction="You are a helpful math tutor. Guide the user through the solution step by step.",
)
```

Run: 
```python
prompt = "how can I solve 8x + 7 = -23"
response = chat_openai.run(prompt=prompt)
```
If `response_schema` is provided, the response is json string that can be converted to the schema object.
```python
response_json = json.loads(response.message.content[0].text)
MathReasoning(**response_json)
```