### PR TITLE
Support AudioContent to invoke llm's capabilities for audio understanding with local audio file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ anthropic = {version = "^0.31.0", optional = true}
 pypdfium2 = {version = "^4.30.0", optional = true}
 imageio = {version = "^2.34.2", optional = true}
 imageio-ffmpeg = {version = "^0.5.1", optional = true}
+soundfile = {version = "^0.12.1", optional = true}
+moviepy = {version = "^1.0.3", optional = true}
 
 [tool.poetry.extras]
 openai = ["openai", "tiktoken"]
@@ -40,7 +42,8 @@ claude = ["anthropic"]
 bedrock = ["boto3"]
 pdf = ["pypdfium2"]
 video = ["imageio", "imageio-ffmpeg"]
-all = ["openai", "tiktoken", "google-generativeai", "google-cloud-aiplatform", "qdrant-client", "chromadb", "usearch", "azure-cosmos", "boto3", "anthropic", "pypdfium2", "imageio", "imageio-ffmpeg"]
+audio = ["soundfile", "moviepy"]
+all = ["openai", "tiktoken", "google-generativeai", "google-cloud-aiplatform", "qdrant-client", "chromadb", "usearch", "azure-cosmos", "boto3", "anthropic", "pypdfium2", "imageio", "imageio-ffmpeg", "soundfile", "moviepy"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/langrila/__init__.py
+++ b/src/langrila/__init__.py
@@ -10,6 +10,7 @@ from .base import (
 from .memory.in_memory import InMemoryConversationMemory
 from .memory.json import JSONConversationMemory
 from .message_content import (
+    AudioContent,
     ContentType,
     ImageContent,
     Message,

--- a/src/langrila/base.py
+++ b/src/langrila/base.py
@@ -32,7 +32,7 @@ from .utils import decode_image, is_valid_uri, model2func
 ROLES = ["system", "user", "assistant", "function", "function_call", "tool"]
 IMAGE_EXTETIONS = ["jpg", "jpeg", "png", "heic", "heif"]
 VIDEO_EXTENSIONS = ["mp4", "mpeg", "mov", "avi", "wmv", "mpg"]
-AUDIO_EXTENSIONS = ["wav", "mp3", "aiff", "aac", "ogg", "flac"]
+AUDIO_EXTENSIONS = ["wav", "mp3", "aiff", "ogg", "flac"]
 
 
 class BaseChatModule(ABC):

--- a/src/langrila/base.py
+++ b/src/langrila/base.py
@@ -243,7 +243,7 @@ class BaseMessage(ABC):
                 elif file_format in VIDEO_EXTENSIONS:
                     return VideoContent(file=content)
                 elif file_format in AUDIO_EXTENSIONS:
-                    return AudioContent(file=content)
+                    return AudioContent(data=content)
                 else:
                     raise ValueError(f"Unsupported file format: {file_format}")
             elif is_uri:

--- a/src/langrila/base.py
+++ b/src/langrila/base.py
@@ -7,6 +7,7 @@ from PIL import Image
 from pydantic import BaseModel
 
 from .message_content import (
+    AudioContent,
     ContentType,
     ImageContent,
     InputType,
@@ -31,6 +32,7 @@ from .utils import decode_image, is_valid_uri, model2func
 ROLES = ["system", "user", "assistant", "function", "function_call", "tool"]
 IMAGE_EXTETIONS = ["jpg", "jpeg", "png", "heic", "heif"]
 VIDEO_EXTENSIONS = ["mp4", "mpeg", "mov", "avi", "wmv", "mpg"]
+AUDIO_EXTENSIONS = ["wav", "mp3", "aiff", "aac", "ogg", "flac"]
 
 
 class BaseChatModule(ABC):
@@ -144,6 +146,10 @@ class BaseMessage(ABC):
     def _format_uri_content(content: str | Path) -> Any:
         raise NotImplementedError
 
+    @staticmethod
+    def _format_audio_content(content: str | Path) -> Any:
+        raise NotImplementedError
+
     @classmethod
     @abstractmethod
     def _from_completion_results(cls, results: CompletionResults) -> list[dict[str, str]]:
@@ -196,6 +202,11 @@ class BaseMessage(ABC):
                     _contents.append(cls._format_uri_content(content=content))
                 except NotImplementedError:
                     pass
+            elif isinstance(content, AudioContent):
+                try:
+                    _contents.append(cls._format_audio_content(content=content))
+                except NotImplementedError:
+                    pass
             else:
                 raise NotImplementedError(f"Message type {type(content)} not implemented")
 
@@ -231,6 +242,8 @@ class BaseMessage(ABC):
                     return PDFContent(file=content)
                 elif file_format in VIDEO_EXTENSIONS:
                     return VideoContent(file=content)
+                elif file_format in AUDIO_EXTENSIONS:
+                    return AudioContent(file=content)
                 else:
                     raise ValueError(f"Unsupported file format: {file_format}")
             elif is_uri:
@@ -271,6 +284,7 @@ class BaseMessage(ABC):
                     ToolCall,
                     URIContent,
                     VideoContent,
+                    AudioContent,
                 ),
             ):
                 _contents.append(content)

--- a/src/langrila/gemini/genai/message.py
+++ b/src/langrila/gemini/genai/message.py
@@ -12,7 +12,15 @@ from google.ai.generativelanguage import (
 )
 
 from ...base import BaseMessage
-from ...message_content import ImageContent, Message, TextContent, ToolCall, ToolContent, URIContent
+from ...message_content import (
+    AudioContent,
+    ImageContent,
+    Message,
+    TextContent,
+    ToolCall,
+    ToolContent,
+    URIContent,
+)
 from ...utils import decode_image
 
 
@@ -52,6 +60,12 @@ class GeminiMessage(BaseMessage):
     def _format_uri_content(content: URIContent) -> Part:
         file_data = FileData(file_uri=content.uri, mime_type=content.mime_type)
         return Part(file_data=file_data)
+
+    @staticmethod
+    def _format_audio_content(content: AudioContent) -> Part:
+        _audio_bytes = content.as_bytes()
+        audio_blob = Blob(data=_audio_bytes, mime_type=content.mime_type)
+        return Part(inline_data=audio_blob)
 
     @staticmethod
     def _format_tool_content(content: ToolContent) -> Part:

--- a/src/langrila/gemini/vertexai/message.py
+++ b/src/langrila/gemini/vertexai/message.py
@@ -10,6 +10,7 @@ from vertexai.generative_models import Content, Part
 
 from ...base import BaseMessage
 from ...message_content import (
+    AudioContent,
     ImageContent,
     Message,
     TextContent,
@@ -64,6 +65,11 @@ class VertexAIMessage(BaseMessage):
     @staticmethod
     def _format_uri_content(content: URIContent) -> Part:
         return Part.from_uri(uri=content.uri, mime_type=content.mime_type)
+
+    @staticmethod
+    def _format_audio_content(content: AudioContent) -> Part:
+        _audio_bytes = content.as_bytes()
+        return Part.from_data(mime_type=content.mime_type, data=_audio_bytes)
 
     @staticmethod
     def _format_tool_content(content: ToolContent) -> Part:

--- a/src/langrila/message_content.py
+++ b/src/langrila/message_content.py
@@ -100,7 +100,7 @@ class AudioContent(BaseModel):
             try:
                 assert Path(data["data"]).is_file()
                 file_format = Path(data["data"]).suffix.lstrip(".").lower()
-                if file_format in ["wav", "mp3", "aiff", "aac", "ogg", "flac"]:
+                if file_format in ["wav", "mp3", "aiff", "ogg", "flac"]:
                     data["mime_type"] = f"audio/{file_format}"
                 elif file_format in ["mp4", "mpeg", "mov", "avi", "wmv", "mpg"]:
                     data["data"], data["sr"] = cls._from_video(data["data"])

--- a/src/langrila/message_content.py
+++ b/src/langrila/message_content.py
@@ -1,8 +1,10 @@
+import io
 from pathlib import Path
 from typing import Any, Literal
 
+import numpy as np
 from PIL import Image
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, field_serializer, model_validator
 
 from .types import PathType
 from .utils import encode_image
@@ -73,19 +75,99 @@ class PDFContent(BaseModel):
         ]
 
 
+class AudioContent(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    file: PathType | bytes | np.ndarray
+    sr: int | None = None
+    mime_type: str | None = None
+
+    def as_bytes(self) -> bytes:
+        import soundfile as sf
+
+        buffer = io.BytesIO()
+        sf.write(
+            buffer, self.file, samplerate=self.sr, format=self.mime_type.split("/")[-1].upper()
+        )
+
+        buffer.seek(0)
+        return buffer.getvalue()
+
+    @model_validator(mode="before")
+    def setup(cls, data):
+        import soundfile as sf
+
+        if isinstance(data, dict) and "file" in data:
+            try:
+                assert Path(data["file"]).is_file()
+                file_format = Path(data["file"]).suffix.lstrip(".").lower()
+                if file_format in ["wav", "mp3", "aiff", "aac", "ogg", "flac"]:
+                    data["mime_type"] = f"audio/{file_format}"
+                elif file_format in ["mp4", "mpeg", "mov", "avi", "wmv", "mpg"]:
+                    data["file"], data["sr"] = cls._from_video(data["file"])
+                    data["mime_type"] = "audio/wav"
+                else:
+                    raise ValueError(f"Invalid audio file format: {file_format}")
+            except Exception:
+                pass
+
+            if isinstance(data["file"], bytes):
+                data["file"], data["sr"] = sf.read(io.BytesIO(data["file"]))
+            elif isinstance(data["file"], io.BytesIO):
+                data["file"], data["sr"] = sf.read(data["file"])
+            elif isinstance(data["file"], (str | Path)):
+                assert Path(data["file"]).is_file()
+                data["file"], data["sr"] = sf.read(data["file"])
+            elif isinstance(data["file"], np.ndarray):
+                pass
+            elif isinstance(data["file"], list):
+                data["file"] = np.array(data["file"])
+            else:
+                raise ValueError("Invalid audio data type")
+
+            data["file"] = cls._convert_stereo_to_mono(data["file"])
+
+        return data
+
+    @field_serializer("file")
+    def serialize_file(self, file: np.ndarray) -> list:
+        return file.tolist()
+
+    @staticmethod
+    def _convert_stereo_to_mono(data: np.ndarray) -> np.ndarray:
+        if data.ndim == 2:
+            return np.mean(data, axis=1)
+        return data
+
+    @staticmethod
+    def _from_video(video_file: PathType) -> tuple[np.ndarray, int]:
+        from moviepy.editor import VideoFileClip
+
+        clip = VideoFileClip(Path(video_file).as_posix())
+        audio = clip.audio
+        fps = audio.fps
+        audio_array = np.array(list(audio.iter_frames()))
+        return audio_array, fps
+
+
 class VideoContent(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     file: PathType
     fps: float = 1.0
     image_resolution: Literal["auto", "low", "high"] = "low"
+    include_audio: bool = False
 
     def as_image_content(self) -> list[ImageContent]:
         from .file_utils.video import sample_frames
 
-        return [
+        frames = [
             ImageContent(image=image, resolution=self.image_resolution)
             for image in sample_frames(self.file, fps=self.fps)
         ]
+
+        if self.include_audio:
+            frames.append(AudioContent(file=self.file))
+
+        return frames
 
 
 class URIContent(BaseModel):
@@ -120,6 +202,7 @@ ContentType = (
     | ToolCall
     | URIContent
     | VideoContent
+    | AudioContent
 )
 
 


### PR DESCRIPTION
`AudioContent` allows us to invoke llm's capabitilies for audio understanding with local audio file. 
[python-soundfile](https://github.com/bastibe/python-soundfile) is used for reading audio file, which can be installed by extra dependencies "audio".

```python
from langrila import AudioContent

AudioContent(
    data="path/to/your/local/audio/file"
)
```

Supported formats are `wav`, `mp3`, `aiff`, `ogg`, and `flac`. 

We can input video file directly to `AudioContent` like this:
 
```python
AudioContent(
    data="path/to/your/local/video/file"
)
```

In this case, audio data is extracted from the video data using [moviepy](https://github.com/Zulko/moviepy). 

Additionally: 
`VideoContent` supports audio extraction from the video data. If we specify `include_audio` attribute of the `VideoContent` as `True`, this content is converted to sequential `ImageContent` of sampled frames with `AudioContent` at the last. Here is an example: 

```python
from langrila import VideoContent

VideoContent(
    file="path/to/your/local/video/file", 
    include_audio=True
).as_image_content()
```
