### PR TITLE
Fix bug occurred by safety contents filter for gemini

### DIFF
--- a/src/langrila/gemini/genai/message.py
+++ b/src/langrila/gemini/genai/message.py
@@ -90,7 +90,7 @@ class GeminiMessage(BaseMessage):
 
         common_contents = []
 
-        for part in serializable.get("parts"):
+        for part in serializable.get("parts", []):
             if part.get("text"):
                 common_contents.append(TextContent(text=part.get("text")))
             elif part.get("inlineData"):

--- a/src/langrila/gemini/vertexai/message.py
+++ b/src/langrila/gemini/vertexai/message.py
@@ -90,7 +90,7 @@ class VertexAIMessage(BaseMessage):
 
         common_contents = []
 
-        for part in serializable.get("parts"):
+        for part in serializable.get("parts", []):
             if part.get("text"):
                 common_contents.append(TextContent(text=part.get("text")))
             elif part.get("inline_data"):


### PR DESCRIPTION
When safety contents filter stricts output generation, there is no parts attribute in the response from the client API. So empty list is necessary as a default value to serialize client response.

Before: 
```python
        for part in serializable.get("parts"):
```

After: 
```python
        for part in serializable.get("parts", []):
```