### PR TITLE
Create Cosmos DB container if not exists and apply ruff

### DIFF
--- a/src/langrila/memory/cosmos.py
+++ b/src/langrila/memory/cosmos.py
@@ -1,32 +1,44 @@
-from azure.cosmos import exceptions, CosmosClient, PartitionKey
+import hashlib
 import logging
 import os
-import hashlib
+
+from azure.cosmos import CosmosClient, PartitionKey, exceptions
 
 from ..base import BaseConversationMemory
 
+
 class CosmosConversationMemory(BaseConversationMemory):
-    def __init__(self, endpoint_env_name: str, key_env_name: str, db_env_name: str, container_env_name: str):
+    def __init__(
+        self,
+        endpoint_env_name: str,
+        key_env_name: str,
+        db_env_name: str,
+        container_name: str,
+        partition_key: str | None = None,
+    ):
         self.endpoint = os.getenv(endpoint_env_name)
         self.key = os.getenv(key_env_name)
         self.dbname = os.getenv(db_env_name)
-        self.containername = os.getenv(container_env_name)
+        self.containername = container_name
+        self.partition_key = partition_key
         # Create a Cosmos client
         try:
             client = CosmosClient(url=self.endpoint, credential=self.key)
         except:
-            logging.error('Could not connect to Cosmos DB')
+            logging.error("Could not connect to Cosmos DB")
             raise ConnectionError
         # Get a database
         try:
             database = client.get_database_client(database=self.dbname)
         except exceptions.CosmosResourceNotFoundError:
-            logging.error(f'Could not find database: {self.dbname}')
-        # Get a container
-        try:
-            self.container = database.get_container_client(self.containername)
-        except exceptions.CosmosResourceExistsError:
-            logging.error(f'Could not find container: {self.containername}')
+            logging.error(f"Could not find database: {self.dbname}")
+
+        # Get or create a container
+        database.create_container_if_not_exists(
+            id=self.containername,
+            partition_key=PartitionKey(path=partition_key) if partition_key else None,
+        )
+        self.container = database.get_container_client(self.containername)
 
     def store(self, conversation_history: list[dict[str, str]]):
         for item in conversation_history:
@@ -35,13 +47,13 @@ class CosmosConversationMemory(BaseConversationMemory):
                 self.container.create_item(item)
             except exceptions.CosmosResourceExistsError:
                 pass
-    
+
     def load(self) -> list[dict[str, str]]:
         result = []
         try:
             items = self.container.read_all_items()
             for item in items:
-                result.append({k: v for k, v in item.items() if k in {"role", "content"}})
+                result.append({k: v for k, v in item.items() if k in {"role", "content", "name"}})
             return result
         except:
             return result

--- a/src/langrila/memory/cosmos.py
+++ b/src/langrila/memory/cosmos.py
@@ -21,12 +21,14 @@ class CosmosConversationMemory(BaseConversationMemory):
         self.dbname = os.getenv(db_env_name)
         self.containername = container_name
         self.partition_key = partition_key
+
         # Create a Cosmos client
         try:
             client = CosmosClient(url=self.endpoint, credential=self.key)
         except:
             logging.error("Could not connect to Cosmos DB")
             raise ConnectionError
+
         # Get a database
         try:
             database = client.get_database_client(database=self.dbname)

--- a/src/langrila/memory/cosmos.py
+++ b/src/langrila/memory/cosmos.py
@@ -1,7 +1,4 @@
-import hashlib
-import logging
 import os
-import warnings
 from typing import Any
 
 from azure.cosmos import CosmosClient, PartitionKey, exceptions

--- a/src/langrila/memory/s3.py
+++ b/src/langrila/memory/s3.py
@@ -1,32 +1,33 @@
-import os
-import logging
-import json
 import hashlib
+import json
+import logging
+import os
 import secrets
 from typing import Optional, Union
 
 import boto3
-from botocore.exceptions import ClientError
 from botocore.client import Config as BotoConfig
+from botocore.exceptions import ClientError
 
 from ..base import BaseConversationMemory
 
+
 class S3ConversationMemory(BaseConversationMemory):
     def __init__(
-            self,
-            bucket: str,
-            *,
-            object_key: Optional[str] = None,
-            region_name: Optional[str] = None,
-            api_version: Optional[str] = None,
-            use_ssl: Optional[bool] = True,
-            verify: Union[str, bool, None] = None,
-            endpoint_url_env_name: Optional[str] = None,
-            aws_access_key_id_env_name: Optional[str] = None,
-            aws_secret_access_key_env_name: Optional[str] = None,
-            aws_session_token_env_name: Optional[str] = None,
-            boto_config: Optional[BotoConfig] = None,
-        ):
+        self,
+        bucket: str,
+        *,
+        object_key: Optional[str] = None,
+        region_name: Optional[str] = None,
+        api_version: Optional[str] = None,
+        use_ssl: Optional[bool] = True,
+        verify: Union[str, bool, None] = None,
+        endpoint_url_env_name: Optional[str] = None,
+        aws_access_key_id_env_name: Optional[str] = None,
+        aws_secret_access_key_env_name: Optional[str] = None,
+        aws_session_token_env_name: Optional[str] = None,
+        boto_config: Optional[BotoConfig] = None,
+    ):
         self.bucket = bucket
         self.object_key = object_key
         self.region_name = region_name
@@ -34,13 +35,19 @@ class S3ConversationMemory(BaseConversationMemory):
         self.use_ssl = use_ssl
         self.verify = verify
         self.endpoint_url = os.getenv(endpoint_url_env_name) if endpoint_url_env_name else None
-        self.aws_access_key_id = os.getenv(aws_access_key_id_env_name) if aws_access_key_id_env_name else None
-        self.aws_secret_access_key = os.getenv(aws_secret_access_key_env_name) if aws_secret_access_key_env_name else None
-        self.aws_session_token = os.getenv(aws_session_token_env_name) if aws_session_token_env_name else None
+        self.aws_access_key_id = (
+            os.getenv(aws_access_key_id_env_name) if aws_access_key_id_env_name else None
+        )
+        self.aws_secret_access_key = (
+            os.getenv(aws_secret_access_key_env_name) if aws_secret_access_key_env_name else None
+        )
+        self.aws_session_token = (
+            os.getenv(aws_session_token_env_name) if aws_session_token_env_name else None
+        )
         self.boto_config = boto_config
 
         self.s3_client = boto3.client(
-            's3',
+            "s3",
             region_name=self.region_name,
             api_version=self.api_version,
             use_ssl=self.use_ssl,
@@ -49,7 +56,7 @@ class S3ConversationMemory(BaseConversationMemory):
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             aws_session_token=self.aws_session_token,
-            config=self.boto_config
+            config=self.boto_config,
         )
 
         try:
@@ -75,12 +82,12 @@ class S3ConversationMemory(BaseConversationMemory):
             return []
         try:
             response = self.s3_client.get_object(Bucket=self.bucket, Key=self.object_key)
-            content = response['Body'].read().decode('utf-8')
+            content = response["Body"].read().decode("utf-8")
             conversation_history = json.loads(content)
             return conversation_history
         except ClientError as e:
-            error_code = e.response['Error']['Code']
-            if error_code == 'NoSuchKey':
+            error_code = e.response["Error"]["Code"]
+            if error_code == "NoSuchKey":
                 return []
             else:
                 logging.error(f"s3 load failed: {e}")


### PR DESCRIPTION
- Update `CosmosConversationMemory` to create container if not exists
- `store()` method run `upsert_item` of cosmos container client
  - previously every turns of conversation is independently kept, but now upserted
- `container_name` and `item_name` become required arguments
- `partition_key` is the same as `container_name` in default, but can specify other value
- Fix type hint
- Apply ruff format
  - `S3ConversationMemory` also