### PR TITLE
Force to use conversation memory for subagents

### DIFF
--- a/notebooks/03.multi_agent.ipynb
+++ b/notebooks/03.multi_agent.ipynb
@@ -76,7 +76,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langrila import Agent, InMemoryConversationMemory\n",
+    "import uuid\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from langrila import Agent, InMemoryConversationMemory, JSONConversationMemory\n",
     "from langrila.anthropic import AnthropicClient\n",
     "from langrila.google import GoogleClient\n",
     "from langrila.openai import OpenAIClient"
@@ -339,11 +342,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "memory_id = str(uuid.uuid4())  # Use your own memory ID\n",
+    "memory_path = f\"./{memory_id}\"\n",
+    "\n",
+    "_memory_path = Path(memory_path)\n",
+    "\n",
+    "if not _memory_path.exists():\n",
+    "    _memory_path.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
     "lights_agent = Agent(\n",
     "    client=vertexai_client,\n",
     "    model=\"gemini-2.0-flash-exp\",\n",
     "    temperature=0.0,\n",
     "    tools=[turn_light_on, adjust_lights],\n",
+    "    conversation_memory=JSONConversationMemory(f\"{memory_path}/lights_agent.json\", exist_ok=True),\n",
     ")\n",
     "\n",
     "disco_ball_agent = Agent(\n",
@@ -352,6 +364,9 @@
     "    temperature=0.0,\n",
     "    tools=[power_disco_ball, stop_disco_ball],\n",
     "    max_tokens=500,\n",
+    "    conversation_memory=JSONConversationMemory(\n",
+    "        f\"{memory_path}/disco_ball_agent.json\", exist_ok=True\n",
+    "    ),\n",
     ")\n",
     "\n",
     "music_agent = Agent(\n",
@@ -359,6 +374,7 @@
     "    model=\"gpt-4o-mini-2024-07-18\",\n",
     "    temperature=0.0,\n",
     "    tools=[start_music, change_music, adjust_volume],\n",
+    "    conversation_memory=JSONConversationMemory(f\"{memory_path}/music_agent.json\", exist_ok=True),\n",
     ")"
    ]
   },
@@ -373,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,62 +399,68 @@
     "    temperature=0.0,\n",
     "    subagents=[lights_agent, disco_ball_agent, music_agent],\n",
     "    planning=True,\n",
+    "    conversation_memory=JSONConversationMemory(f\"{memory_id}/orchestrator.json\", exist_ok=True),\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m[2025-01-02 20:10:44]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nTurn this place into a party mood!\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - change_music: Change the music genre and BPM.\\n  - adjust_volume: Adjust the volume of the music.\\n')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:44]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:48]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='### Plan to Turn the Place into a Party Mood\\n\\n1. **Turn on the Lights**: \\n   - Invoke `lights_agent.turn_light_on` to ensure the lights are on.\\n\\n2. **Adjust Lighting**: \\n   - Invoke `lights_agent.adjust_lights` to set a vibrant brightness level suitable for a party atmosphere.\\n\\n3. **Activate the Disco Ball**: \\n   - Invoke `disco_ball_agent.power_disco_ball` to add a fun visual element to the party.\\n\\n4. **Start the Music**: \\n   - Invoke `music_agent.start_music` to play upbeat music that fits the party vibe.\\n\\n5. **Adjust Music Volume**: \\n   - Optionally, invoke `music_agent.adjust_volume` to ensure the music is at an appropriate level for the party.\\n\\nBy following these steps, the place will be transformed into a lively party environment!')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:48]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:48]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:51]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Turn the lights on.\"}', call_id='call_gWv8qjF0bT7eWehOepEoBKQO'), ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Adjust the brightness of the lights to a vibrant level suitable for a party.\"}', call_id='call_TOveSBNz7mPuyAG8a4d0rGPO'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Power the spinning disco ball.\"}', call_id='call_1vDrg6SaMpUkLKTj1I7eAbCl'), ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Turn on the music with an upbeat genre, BPM, and volume.\"}', call_id='call_K7k2ZVndhUs1nkp794v26DVj')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:51]\u001b[0m \u001b[1mINFO | Running tool: route_lights_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:51]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Turn the lights on.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:51]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:52]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='turn_light_on', args='{}', call_id='sWnVA5HjR6uGON9fiBuRz29D')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:52]\u001b[0m \u001b[1mINFO | Running tool: turn_light_on\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:52]\u001b[0m \u001b[1mINFO | Tool: turn_light_on successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:52]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Lights are now on! Brightness: 0.83', error=None, call_id='sWnVA5HjR6uGON9fiBuRz29D', args='{}', name='turn_light_on')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:52]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:53]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='OK. The lights are on.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:53]\u001b[0m \u001b[1mINFO | Tool: route_lights_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:53]\u001b[0m \u001b[1mINFO | Running tool: route_lights_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:53]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Adjust the brightness of the lights to a vibrant level suitable for a party.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:53]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:55]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Sure, what brightness level would you like to set? Please provide a value between 0 and 1.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:55]\u001b[0m \u001b[1mINFO | Tool: route_lights_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:55]\u001b[0m \u001b[1mINFO | Running tool: route_disco_ball_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:55]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Power the spinning disco ball.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:55]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Certainly! I can help you power the spinning disco ball using the available function. Let\\'s use the \"power_disco_ball\" function to turn it on.'), ToolCallResponse(name='power_disco_ball', args='{\"power\": true}', call_id='toolu_016caA8Syn6BFjWsrBpiQQvs')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:57]\u001b[0m \u001b[1mINFO | Running tool: power_disco_ball\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:57]\u001b[0m \u001b[1mINFO | Tool: power_disco_ball successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Disco ball is spinning!', error=None, call_id='toolu_016caA8Syn6BFjWsrBpiQQvs', args='{\"power\": true}', name='power_disco_ball')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:57]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:59]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Great! The disco ball has been powered on and is now spinning. The function returned the message \"Disco ball is spinning!\" which confirms that the action was successful.\\n\\nIs there anything else you\\'d like to do with the disco ball or any other requests you have?')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:59]\u001b[0m \u001b[1mINFO | Tool: route_disco_ball_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:59]\u001b[0m \u001b[1mINFO | Running tool: route_music_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:59]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Turn on the music with an upbeat genre, BPM, and volume.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:10:59]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='start_music', args='{}', call_id='call_QCGXd8O5wJWmVhfC94IEq2Br')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:00]\u001b[0m \u001b[1mINFO | Running tool: start_music\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:00]\u001b[0m \u001b[1mINFO | Tool: start_music successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Starting music! Genre: classical, BPM: 120, Volume: 0.5266346818791816', error=None, call_id='call_QCGXd8O5wJWmVhfC94IEq2Br', args='{}', name='start_music')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:00]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:02]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"The music has been turned on! It's playing classical music at a BPM of 120 with a volume level of approximately 0.53. Enjoy!\")]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:02]\u001b[0m \u001b[1mINFO | Tool: route_music_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:02]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='OK. The lights are on.', error=None, call_id='call_gWv8qjF0bT7eWehOepEoBKQO', args='{\"instruction\": \"Turn the lights on.\"}', name='route_lights_agent'), ToolUsePrompt(output='Sure, what brightness level would you like to set? Please provide a value between 0 and 1.', error=None, call_id='call_TOveSBNz7mPuyAG8a4d0rGPO', args='{\"instruction\": \"Adjust the brightness of the lights to a vibrant level suitable for a party.\"}', name='route_lights_agent'), ToolUsePrompt(output='Great! The disco ball has been powered on and is now spinning. The function returned the message \"Disco ball is spinning!\" which confirms that the action was successful.\\n\\nIs there anything else you\\'d like to do with the disco ball or any other requests you have?', error=None, call_id='call_1vDrg6SaMpUkLKTj1I7eAbCl', args='{\"instruction\": \"Power the spinning disco ball.\"}', name='route_disco_ball_agent'), ToolUsePrompt(output=\"The music has been turned on! It's playing classical music at a BPM of 120 with a volume level of approximately 0.53. Enjoy!\", error=None, call_id='call_K7k2ZVndhUs1nkp794v26DVj', args='{\"instruction\": \"Turn on the music with an upbeat genre, BPM, and volume.\"}', name='route_music_agent')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:02]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:11:04]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"The party mood has been successfully set! Here's what has been done:\\n\\n1. **Lights**: The lights are on and ready.\\n2. **Brightness Adjustment**: Please provide a brightness level between 0 and 1 to adjust the lights to a vibrant level.\\n3. **Disco Ball**: The disco ball is spinning, adding a fun visual element to the atmosphere.\\n4. **Music**: Upbeat music is playing at a BPM of 120 with a volume level of approximately 0.53.\\n\\nLet me know the brightness level you'd like to set or if there's anything else you'd like to do!\")]\u001b[0m\n"
+      "\u001b[32m[2025-01-05 21:50:15]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nTurn this place into a party mood!\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - change_music: Change the music genre and BPM.\\n  - adjust_volume: Adjust the volume of the music.\\n')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:15]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:18]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='### Plan to Turn the Place into a Party Mood\\n\\n1. **Turn on the Lights**: \\n   - Invoke `lights_agent.turn_light_on` to ensure the lights are on.\\n\\n2. **Adjust the Lighting**: \\n   - Invoke `lights_agent.adjust_lights` to set a vibrant brightness level suitable for a party atmosphere.\\n\\n3. **Activate the Disco Ball**: \\n   - Invoke `disco_ball_agent.power_disco_ball` to add a fun visual element to the party.\\n\\n4. **Start the Music**: \\n   - Invoke `music_agent.start_music` to play upbeat music that fits the party vibe.\\n\\n5. **Adjust Music Volume**: \\n   - Optionally, invoke `music_agent.adjust_volume` to ensure the music is at an appropriate level for the party setting.\\n\\nBy following these steps, the place will be transformed into a lively party environment!')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:18]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:18]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:20]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Turn the lights on.\"}', call_id='call_GJObQuM8JlieC1EovB8MKPSJ'), ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Adjust the brightness of the lights to a vibrant level suitable for a party.\"}', call_id='call_UMvm8MFAAs1ZIzg0Mu7SWzxI'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Power the spinning disco ball.\"}', call_id='call_BxYXHlwlexTcFwS0v7ssF3No'), ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Turn on the music with an upbeat genre, BPM, and volume.\"}', call_id='call_wxkDiVDcSB5ulwo7BtXU7dRB')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:20]\u001b[0m \u001b[1mINFO | Running tool: route_lights_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:20]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Turn the lights on.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:20]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:22]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='turn_light_on', args='{}', call_id='7A3GJqIxeJYyAJLZ1PzZVTfA')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:22]\u001b[0m \u001b[1mINFO | Running tool: turn_light_on\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:22]\u001b[0m \u001b[1mINFO | Tool: turn_light_on successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:22]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Lights are now on! Brightness: 0.60', error=None, call_id='7A3GJqIxeJYyAJLZ1PzZVTfA', args='{}', name='turn_light_on')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:22]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:24]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='OK. The lights are now on.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:24]\u001b[0m \u001b[1mINFO | Tool: route_lights_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:24]\u001b[0m \u001b[1mINFO | Running tool: route_lights_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:24]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Adjust the brightness of the lights to a vibrant level suitable for a party.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:24]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:25]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='adjust_lights', args='{\"brightness\": 0.9}', call_id='I71Qp0krSBWTOMiq1gwA66sk')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:25]\u001b[0m \u001b[1mINFO | Running tool: adjust_lights\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:25]\u001b[0m \u001b[1mINFO | Tool: adjust_lights successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:25]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Lights are now set to 0.9', error=None, call_id='I71Qp0krSBWTOMiq1gwA66sk', args='{\"brightness\": 0.9}', name='adjust_lights')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:25]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:26]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"OK. I've adjusted the brightness of the lights to 0.9.\")]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:26]\u001b[0m \u001b[1mINFO | Tool: route_lights_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:26]\u001b[0m \u001b[1mINFO | Running tool: route_disco_ball_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:26]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Power the spinning disco ball.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:26]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:28]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Certainly! I can help you power the spinning disco ball using the available function. Let\\'s use the \"power_disco_ball\" function to turn it on.'), ToolCallResponse(name='power_disco_ball', args='{\"power\": true}', call_id='toolu_01TpsQXCRfcyrQFmFLnhHoeS')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:28]\u001b[0m \u001b[1mINFO | Running tool: power_disco_ball\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:28]\u001b[0m \u001b[1mINFO | Tool: power_disco_ball successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:28]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Disco ball is spinning!', error=None, call_id='toolu_01TpsQXCRfcyrQFmFLnhHoeS', args='{\"power\": true}', name='power_disco_ball')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:28]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:30]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Great! The disco ball has been powered on and is now spinning. The function returned the message \"Disco ball is spinning!\" which confirms that the action was successful.\\n\\nIs there anything else you\\'d like to do with the disco ball or any other requests you have?')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:30]\u001b[0m \u001b[1mINFO | Tool: route_disco_ball_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:30]\u001b[0m \u001b[1mINFO | Running tool: route_music_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:30]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Turn on the music with an upbeat genre, BPM, and volume.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:30]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:31]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='start_music', args='{}', call_id='call_S0CJOkr6WxFcyhT595nIlGWb')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:31]\u001b[0m \u001b[1mINFO | Running tool: start_music\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:31]\u001b[0m \u001b[1mINFO | Tool: start_music successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:31]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Starting music! Genre: hip-hop, BPM: 120, Volume: 0.9105972755969132', error=None, call_id='call_S0CJOkr6WxFcyhT595nIlGWb', args='{}', name='start_music')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:31]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:32]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='The music is now playing! Genre: Hip-hop, BPM: 120, Volume: 0.91. Enjoy the upbeat vibes!')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:32]\u001b[0m \u001b[1mINFO | Tool: route_music_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:32]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='OK. The lights are now on.', error=None, call_id='call_GJObQuM8JlieC1EovB8MKPSJ', args='{\"instruction\": \"Turn the lights on.\"}', name='route_lights_agent'), ToolUsePrompt(output=\"OK. I've adjusted the brightness of the lights to 0.9.\", error=None, call_id='call_UMvm8MFAAs1ZIzg0Mu7SWzxI', args='{\"instruction\": \"Adjust the brightness of the lights to a vibrant level suitable for a party.\"}', name='route_lights_agent'), ToolUsePrompt(output='Great! The disco ball has been powered on and is now spinning. The function returned the message \"Disco ball is spinning!\" which confirms that the action was successful.\\n\\nIs there anything else you\\'d like to do with the disco ball or any other requests you have?', error=None, call_id='call_BxYXHlwlexTcFwS0v7ssF3No', args='{\"instruction\": \"Power the spinning disco ball.\"}', name='route_disco_ball_agent'), ToolUsePrompt(output='The music is now playing! Genre: Hip-hop, BPM: 120, Volume: 0.91. Enjoy the upbeat vibes!', error=None, call_id='call_wxkDiVDcSB5ulwo7BtXU7dRB', args='{\"instruction\": \"Turn on the music with an upbeat genre, BPM, and volume.\"}', name='route_music_agent')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:32]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:35]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"The party mood has been successfully set! Here's what has been done:\\n\\n1. **Lights**: The lights are now on and the brightness has been adjusted to a vibrant level (0.9).\\n2. **Disco Ball**: The disco ball is powered on and spinning, adding a fun visual element to the atmosphere.\\n3. **Music**: Upbeat music is playing with the genre set to Hip-hop, BPM at 120, and volume at 0.91.\\n\\nEnjoy the party vibes! If you have any other requests or adjustments, feel free to let me know!\")]\u001b[0m\n"
      ]
     }
    ],
@@ -457,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -466,12 +488,11 @@
      "text": [
       "The party mood has been successfully set! Here's what has been done:\n",
       "\n",
-      "1. **Lights**: The lights are on and ready.\n",
-      "2. **Brightness Adjustment**: Please provide a brightness level between 0 and 1 to adjust the lights to a vibrant level.\n",
-      "3. **Disco Ball**: The disco ball is spinning, adding a fun visual element to the atmosphere.\n",
-      "4. **Music**: Upbeat music is playing at a BPM of 120 with a volume level of approximately 0.53.\n",
+      "1. **Lights**: The lights are now on and the brightness has been adjusted to a vibrant level (0.9).\n",
+      "2. **Disco Ball**: The disco ball is powered on and spinning, adding a fun visual element to the atmosphere.\n",
+      "3. **Music**: Upbeat music is playing with the genre set to Hip-hop, BPM at 120, and volume at 0.91.\n",
       "\n",
-      "Let me know the brightness level you'd like to set or if there's anything else you'd like to do!\n"
+      "Enjoy the party vibes! If you have any other requests or adjustments, feel free to let me know!\n"
      ]
     }
    ],
@@ -488,23 +509,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[('music_agent',\n",
-       "  Usage(model_name='gpt-4o-mini-2024-07-18', prompt_tokens=441, output_tokens=43)),\n",
-       " ('lights_agent',\n",
-       "  Usage(model_name='gemini-2.0-flash-exp', prompt_tokens=61, output_tokens=23)),\n",
-       " ('disco_ball_agent',\n",
+       "[('disco_ball_agent',\n",
        "  Usage(model_name='claude-3-5-sonnet-20240620', prompt_tokens=990, output_tokens=149)),\n",
+       " ('lights_agent',\n",
+       "  Usage(model_name='gemini-2.0-flash-exp', prompt_tokens=211, output_tokens=22)),\n",
        " ('root',\n",
-       "  Usage(model_name='gpt-4o-mini-2024-07-18', prompt_tokens=1958, output_tokens=424))]"
+       "  Usage(model_name='gpt-4o-mini-2024-07-18', prompt_tokens=1954, output_tokens=420)),\n",
+       " ('music_agent',\n",
+       "  Usage(model_name='gpt-4o-mini-2024-07-18', prompt_tokens=442, output_tokens=41))]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -518,6 +539,56 @@
    "metadata": {},
    "source": [
     "Top-level orchestrator name is `root`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Individual subagents store their own inputs and outputs. You can access those conversation histories by calling `load_history()` of focused agent. Here is an example to access to the history of music_agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Agent(name=music_agent)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orchestrator.subagents[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Turn on the music with an upbeat genre, BPM, and volume.')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='start_music', args='{}', call_id='call_S0CJOkr6WxFcyhT595nIlGWb')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='Starting music! Genre: hip-hop, BPM: 120, Volume: 0.9105972755969132', error=None, call_id='call_S0CJOkr6WxFcyhT595nIlGWb', args='{}', name='start_music')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='The music is now playing! Genre: Hip-hop, BPM: 120, Volume: 0.91. Enjoy the upbeat vibes!')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None)]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orchestrator.subagents[2].load_history()"
    ]
   },
   {
@@ -545,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,8 +680,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you don't specify the conversation memory for subagent, `InMemoryConversationMemory` is internally used in default, which is not persisted automatically. Each subagent always need own conversation memory because the state within the multi-agent is kept or updated based on the conversation history and response schema if specified. Please be aware of using internal memory even if you don't specify the conversation memory for the subagent."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +708,6 @@
     "    max_tokens=500,\n",
     "    response_schema_as_tool=DiscoBallSchema,  # The state of the disco ball.\n",
     ")\n",
-    "\n",
     "\n",
     "music_power_agent = Agent(\n",
     "    client=openai_client,\n",
@@ -657,7 +734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -685,80 +762,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m[2025-01-02 20:21:49]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nTurn this place into a party mood.\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - music_power_agent\\n    - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - music_control_agent\\n    - change_music: Change the music genre and BPM.\\n    - adjust_volume: Adjust the volume of the music.\\n    - change_bpm: Change the BPM of the music.\\n')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:49]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:51]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='### Plan to Turn the Place into a Party Mood:\\n\\n1. **Lights Setup**:\\n   - Use `lights_agent` to turn the lights on.\\n   - Adjust the brightness of the lights to create a vibrant or dimmed party atmosphere using `adjust_lights`.\\n\\n2. **Disco Ball Activation**:\\n   - Use `disco_ball_agent` to power the spinning disco ball for a fun and dynamic visual effect.\\n\\n3. **Music Setup**:\\n   - Use `music_agent.music_power_agent` to start the music.\\n   - If needed, use `music_agent.music_control_agent` to:\\n     - Change the music genre and BPM to match the party vibe.\\n     - Adjust the volume to an appropriate level for the party.\\n\\n4. **Final Adjustments**:\\n   - Fine-tune the lights, disco ball, and music settings as needed to ensure the perfect party mood.\\n\\nWould you like me to execute this plan?')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:51]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:51]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:53]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-friendly level, such as 0.8.\"}', call_id='call_KZZDW9yVR21nhAJaVW8Ft2il'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Power the disco ball and make it spin for a party atmosphere.\"}', call_id='call_vN5lDDDtkopxPKH9qtFuRKUQ'), ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Start the music with a random genre, BPM, and volume to initiate the party mood.\"}', call_id='call_rm1IY9aZxQAIQlaPuXey0V3i')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:53]\u001b[0m \u001b[1mINFO | Running tool: route_lights_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:53]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Turn on the lights and adjust the brightness to a party-friendly level, such as 0.8.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:53]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:54]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='turn_light_on', args='{}', call_id='B67QE6XJ8VzcFyh59a8DzpUR'), ToolCallResponse(name='adjust_lights', args='{\"brightness\": 0.8}', call_id='CyzmU7WDqdUpSj13eov7pjpx')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:54]\u001b[0m \u001b[1mINFO | Running tool: turn_light_on\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:54]\u001b[0m \u001b[1mINFO | Tool: turn_light_on successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:54]\u001b[0m \u001b[1mINFO | Running tool: adjust_lights\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:54]\u001b[0m \u001b[1mINFO | Tool: adjust_lights successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:54]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Lights are now on! Brightness: 0.89', error=None, call_id='B67QE6XJ8VzcFyh59a8DzpUR', args='{}', name='turn_light_on'), ToolUsePrompt(output='Lights are now set to 0.8', error=None, call_id='CyzmU7WDqdUpSj13eov7pjpx', args='{\"brightness\": 0.8}', name='adjust_lights')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:54]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:55]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"brightness\": 0.8}', call_id='DGsrAXCFfG63eimapsdg3MEn')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:55]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:55]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:55]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"brightness\": 0.8}')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[1mINFO | Tool: route_lights_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[1mINFO | Running tool: route_disco_ball_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Power the disco ball and make it spin for a party atmosphere.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='power_disco_ball', args='{\"power\":true}', call_id='call_w4czLtmqLINetTfMJQh8cTBC')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[1mINFO | Running tool: power_disco_ball\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[1mINFO | Tool: power_disco_ball successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Disco ball is spinning!', error=None, call_id='call_w4czLtmqLINetTfMJQh8cTBC', args='{\"power\":true}', name='power_disco_ball')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:56]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='The disco ball is powered and spinning, creating a perfect party atmosphere!')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text=\"Decide the next action based on the conversation. If you have all information for answering the user, run 'final_result' tool. If you need more information, invoke other tool to get necessary information. \")]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"power\":true,\"spinning\":true}', call_id='call_ezogOn5uDxqgPt9YljDhY0qJ')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"power\": true, \"spinning\": true}')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[1mINFO | Tool: route_disco_ball_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[1mINFO | Running tool: route_music_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Start the music with a random genre, BPM, and volume to initiate the party mood.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:21:57]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"Certainly! I'd be happy to start the music with random settings to get the party mood going. To do this, we'll use the music power agent to turn on the music with randomly selected genre, BPM, and volume. Let's make the function call to start the music.\"), ToolCallResponse(name='route_music_power_agent', args='{\"instruction\": \"Please start the music with a random genre, BPM, and volume to initiate the party mood.\"}', call_id='toolu_01Sh3164xcDTy64uogeAHfd1')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:00]\u001b[0m \u001b[1mINFO | Running tool: route_music_power_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please start the music with a random genre, BPM, and volume to initiate the party mood.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:00]\u001b[0m \u001b[1mINFO | music_power_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:01]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='start_music', args='{}', call_id='call_YsuWcoyCVGad0rkfKjeTvXMA')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:01]\u001b[0m \u001b[1mINFO | Running tool: start_music\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:01]\u001b[0m \u001b[1mINFO | Tool: start_music successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:01]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Starting music! Genre: pop, BPM: 120, Volume: 0.5022160140768197', error=None, call_id='call_YsuWcoyCVGad0rkfKjeTvXMA', args='{}', name='start_music')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:01]\u001b[0m \u001b[1mINFO | music_power_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:02]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='The music has started! 🎶 Genre: Pop, BPM: 120, Volume: 50%. Let the party begin!')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:02]\u001b[0m \u001b[1mINFO | Tool: route_music_power_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:02]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='The music has started! 🎶 Genre: Pop, BPM: 120, Volume: 50%. Let the party begin!', error=None, call_id='toolu_01Sh3164xcDTy64uogeAHfd1', args='{\"instruction\": \"Please start the music with a random genre, BPM, and volume to initiate the party mood.\"}', name='route_music_power_agent')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:02]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:06]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"Great news! The music has been started successfully. Here's a summary of the randomly selected settings:\\n\\n- Genre: Pop\\n- BPM (Beats Per Minute): 120\\n- Volume: 50%\\n\\nThe party mood is now set with some upbeat pop music playing at a moderate tempo and volume. This should create a nice atmosphere to get things started. \\n\\nIs there anything else you'd like me to do with the music? I can adjust the volume, change the genre, or modify the BPM if you'd like. Just let me know!\")]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:06]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text=\"Decide the next action based on the conversation. If you have all information for answering the user, run 'final_result' tool. If you need more information, invoke other tool to get necessary information. \")]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:06]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:09]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"Based on the conversation so far, we have all the necessary information to provide a final answer to the user's request. The music has been started with random settings as requested, and we have the specific details of those settings. Let's use the 'final_answer' tool to summarize the action taken and provide the current state of the music.\"), ToolCallResponse(name='final_answer', args='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}', call_id='toolu_01PZV7cqBGDfWu8jhwHE7tT9')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:09]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:09]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:09]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:09]\u001b[0m \u001b[1mINFO | Tool: route_music_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:09]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='{\"brightness\": 0.8}', error=None, call_id='call_KZZDW9yVR21nhAJaVW8Ft2il', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-friendly level, such as 0.8.\"}', name='route_lights_agent'), ToolUsePrompt(output='{\"power\": true, \"spinning\": true}', error=None, call_id='call_vN5lDDDtkopxPKH9qtFuRKUQ', args='{\"instruction\": \"Power the disco ball and make it spin for a party atmosphere.\"}', name='route_disco_ball_agent'), ToolUsePrompt(output='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}', error=None, call_id='call_rm1IY9aZxQAIQlaPuXey0V3i', args='{\"instruction\": \"Start the music with a random genre, BPM, and volume to initiate the party mood.\"}', name='route_music_agent')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:09]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:10]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.5},\"lights\":{\"brightness\":0.8}}', call_id='call_UM8CW6rlAlYR7GdZiGWl57Iw')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:10]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:10]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:22:10]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}')]\u001b[0m\n"
+      "\u001b[32m[2025-01-05 21:50:35]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nTurn this place into a party mood.\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - music_power_agent\\n    - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - music_control_agent\\n    - change_music: Change the music genre and BPM.\\n    - adjust_volume: Adjust the volume of the music.\\n    - change_bpm: Change the BPM of the music.\\n')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:35]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:37]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='### Plan to Turn the Place into a Party Mood:\\n\\n1. **Lights Setup**:\\n   - Use `lights_agent` to turn the lights on (`turn_light_on`).\\n   - Adjust the brightness of the lights to a party-appropriate level using `adjust_lights`.\\n\\n2. **Disco Ball Activation**:\\n   - Use `disco_ball_agent` to power the spinning disco ball (`power_disco_ball`).\\n\\n3. **Music Setup**:\\n   - Use `music_agent.music_power_agent` to start the music (`start_music`).\\n   - If needed, use `music_agent.music_control_agent` to:\\n     - Change the music genre and BPM to a party-friendly style (`change_music`).\\n     - Adjust the volume to an energetic level (`adjust_volume`).\\n\\n4. **Final Adjustments**:\\n   - Ensure all elements (lights, disco ball, and music) are synchronized for a cohesive party atmosphere.\\n\\nWould you like me to execute this plan?')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:37]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:37]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:39]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-appropriate level (e.g., 0.8).\"}', call_id='call_KKB8c9ih5rZR07oxUxVkg3St'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Power the disco ball and ensure it is spinning.\"}', call_id='call_4at0Okh6BKsO2q84meYfQo6M'), ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Start the music and ensure it is set to a party-friendly genre, BPM, and volume.\"}', call_id='call_BZkNx5HTA35RJosmA8pZ5AKl')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:39]\u001b[0m \u001b[1mINFO | Running tool: route_lights_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:39]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Turn on the lights and adjust the brightness to a party-appropriate level (e.g., 0.8).')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:39]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:40]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='turn_light_on', args='{}', call_id='QxQOVKGT25THpDCJipkhZWbS'), ToolCallResponse(name='adjust_lights', args='{\"brightness\": 0.8}', call_id='yB1rkphjrm6qtc1dZqy93h1d')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:40]\u001b[0m \u001b[1mINFO | Running tool: turn_light_on\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:40]\u001b[0m \u001b[1mINFO | Tool: turn_light_on successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:40]\u001b[0m \u001b[1mINFO | Running tool: adjust_lights\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:40]\u001b[0m \u001b[1mINFO | Tool: adjust_lights successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:40]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Lights are now on! Brightness: 0.80', error=None, call_id='QxQOVKGT25THpDCJipkhZWbS', args='{}', name='turn_light_on'), ToolUsePrompt(output='Lights are now set to 0.8', error=None, call_id='yB1rkphjrm6qtc1dZqy93h1d', args='{\"brightness\": 0.8}', name='adjust_lights')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:40]\u001b[0m \u001b[1mINFO | lights_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:41]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"brightness\": 0.8}', call_id='49h7PCkdIOBEo4aPW7c4hc1B')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:41]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:41]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:41]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"brightness\": 0.8}')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:41]\u001b[0m \u001b[1mINFO | Tool: route_lights_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:41]\u001b[0m \u001b[1mINFO | Running tool: route_disco_ball_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:41]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Power the disco ball and ensure it is spinning.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:41]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:42]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='power_disco_ball', args='{\"power\":true}', call_id='call_fl5R1gx93L5UntHrcKE0vn5B')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:42]\u001b[0m \u001b[1mINFO | Running tool: power_disco_ball\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:42]\u001b[0m \u001b[1mINFO | Tool: power_disco_ball successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:42]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Disco ball is spinning!', error=None, call_id='call_fl5R1gx93L5UntHrcKE0vn5B', args='{\"power\":true}', name='power_disco_ball')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:42]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='The disco ball is powered and spinning!')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text=\"Decide the next action based on the conversation. If you have all information for answering the user, run 'final_result' tool. If you need more information, invoke other tool to get necessary information. \")]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"power\":true,\"spinning\":true}', call_id='call_rp0JIpZkHFPbQ39GFv3lkOiI')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"power\": true, \"spinning\": true}')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[1mINFO | Tool: route_disco_ball_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[1mINFO | Running tool: route_music_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Start the music and ensure it is set to a party-friendly genre, BPM, and volume.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:43]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:47]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"Certainly! I'll start the music for you and make sure it's set to a party-friendly configuration. To do this, I'll use the music power agent to start the music. The agent will randomly select a genre, BPM, and volume, but I'll instruct it to focus on party-friendly settings.\"), ToolCallResponse(name='route_music_power_agent', args='{\"instruction\": \"Start the music with settings suitable for a party. Choose a genre that\\'s typically popular for parties (like pop, hip-hop, or rock), set the BPM to an energetic level (around 120-140 BPM), and set the volume to a moderately high level (around 0.7-0.8) to create a lively atmosphere without being too loud.\"}', call_id='toolu_0197rYxcv6RX9sSpBfA5rC4D')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:47]\u001b[0m \u001b[1mINFO | Running tool: route_music_power_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:47]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text=\"Start the music with settings suitable for a party. Choose a genre that's typically popular for parties (like pop, hip-hop, or rock), set the BPM to an energetic level (around 120-140 BPM), and set the volume to a moderately high level (around 0.7-0.8) to create a lively atmosphere without being too loud.\")]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:47]\u001b[0m \u001b[1mINFO | music_power_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:48]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='start_music', args='{}', call_id='call_fbXGUmSJV4F4QWBhtHdAgmcg')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:48]\u001b[0m \u001b[1mINFO | Running tool: start_music\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:48]\u001b[0m \u001b[1mINFO | Tool: start_music successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:48]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Starting music! Genre: jazz, BPM: 120, Volume: 0.8883200024023981', error=None, call_id='call_fbXGUmSJV4F4QWBhtHdAgmcg', args='{}', name='start_music')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:48]\u001b[0m \u001b[1mINFO | music_power_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:50]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"The music has started! It's set to a jazz genre with a BPM of 120 and a volume of approximately 0.89. While jazz isn't the typical party genre, it can still create a lively atmosphere. Enjoy the tunes!\")]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:50]\u001b[0m \u001b[1mINFO | Tool: route_music_power_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:50]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output=\"The music has started! It's set to a jazz genre with a BPM of 120 and a volume of approximately 0.89. While jazz isn't the typical party genre, it can still create a lively atmosphere. Enjoy the tunes!\", error=None, call_id='toolu_0197rYxcv6RX9sSpBfA5rC4D', args='{\"instruction\": \"Start the music with settings suitable for a party. Choose a genre that\\'s typically popular for parties (like pop, hip-hop, or rock), set the BPM to an energetic level (around 120-140 BPM), and set the volume to a moderately high level (around 0.7-0.8) to create a lively atmosphere without being too loud.\"}', name='route_music_power_agent')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:50]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:53]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Great! The music has started, but it seems the random selection has given us a slightly unexpected result for a party. Let me adjust it to make it more party-friendly:'), ToolCallResponse(name='route_music_control_agent', args='{\"instruction\": \"Change the music to a more party-friendly genre like pop or hip-hop. Keep the BPM at 120 as it\\'s good for dancing. Slightly lower the volume to 0.8 to ensure comfortable conversation is still possible.\"}', call_id='toolu_01J7GDwReRuV1VCaxpiRr7cz')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:53]\u001b[0m \u001b[1mINFO | Running tool: route_music_control_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:53]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text=\"Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nChange the music to a more party-friendly genre like pop or hip-hop. Keep the BPM at 120 as it's good for dancing. Slightly lower the volume to 0.8 to ensure comfortable conversation is still possible.\\n\\nCapabilities:\\n- change_music: Change the music genre and BPM.\\n- adjust_volume: Adjust the volume of the music.\\n- change_bpm: Change the BPM of the music.\\n\")]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:53]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:55]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Okay, here\\'s the plan:\\n\\n1. **Change Genre:** Use the `change_music` tool to switch the music genre to either \"pop\" or \"hip-hop\". I\\'ll choose \"pop\" for this plan, but either would work. I\\'ll also set the BPM to 120 within this call.\\n2. **Adjust Volume:** Use the `adjust_volume` tool to lower the volume to 0.8.\\n\\nThis plan directly addresses the requirements in a concise manner.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:55]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:55]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:56]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='change_music', args='{\"bpm\": 120, \"genre\": \"pop\"}', call_id='URQdj3CGuFVgvVfvPW3meNCW'), ToolCallResponse(name='adjust_volume', args='{\"volume\": 0.8}', call_id='VCca2YxuMTOC8AKJp6bSzM4u')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:56]\u001b[0m \u001b[1mINFO | Running tool: change_music\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:56]\u001b[0m \u001b[1mINFO | Tool: change_music successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:56]\u001b[0m \u001b[1mINFO | Running tool: adjust_volume\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:56]\u001b[0m \u001b[1mINFO | Tool: adjust_volume successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:56]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Changing music to pop with BPM 120', error=None, call_id='URQdj3CGuFVgvVfvPW3meNCW', args='{\"bpm\": 120, \"genre\": \"pop\"}', name='change_music'), ToolUsePrompt(output='Volume is now set to 0.8', error=None, call_id='VCca2YxuMTOC8AKJp6bSzM4u', args='{\"volume\": 0.8}', name='adjust_volume')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:56]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"OK, I've changed the music to pop with a BPM of 120 and adjusted the volume to 0.8.\")]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:57]\u001b[0m \u001b[1mINFO | Tool: route_music_control_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:57]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output=\"OK, I've changed the music to pop with a BPM of 120 and adjusted the volume to 0.8.\", error=None, call_id='toolu_01J7GDwReRuV1VCaxpiRr7cz', args='{\"instruction\": \"Change the music to a more party-friendly genre like pop or hip-hop. Keep the BPM at 120 as it\\'s good for dancing. Slightly lower the volume to 0.8 to ensure comfortable conversation is still possible.\"}', name='route_music_control_agent')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:57]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:59]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"Excellent! I've made the adjustments to create a more party-friendly atmosphere. Here's a summary of the current music settings:\"), ToolCallResponse(name='final_answer', args='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', call_id='toolu_01PCG6EtqCBfsQEorDet3CJk')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:59]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:59]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:59]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:59]\u001b[0m \u001b[1mINFO | Tool: route_music_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:59]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='{\"brightness\": 0.8}', error=None, call_id='call_KKB8c9ih5rZR07oxUxVkg3St', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-appropriate level (e.g., 0.8).\"}', name='route_lights_agent'), ToolUsePrompt(output='{\"power\": true, \"spinning\": true}', error=None, call_id='call_4at0Okh6BKsO2q84meYfQo6M', args='{\"instruction\": \"Power the disco ball and ensure it is spinning.\"}', name='route_disco_ball_agent'), ToolUsePrompt(output='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', error=None, call_id='call_BZkNx5HTA35RJosmA8pZ5AKl', args='{\"instruction\": \"Start the music and ensure it is set to a party-friendly genre, BPM, and volume.\"}', name='route_music_agent')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:50:59]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.8},\"lights\":{\"brightness\":0.8}}', call_id='call_gDjp1862fyoBjhnoUh2Jhj5a')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:00]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:00]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}')]\u001b[0m\n"
      ]
     }
    ],
@@ -770,25 +862,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[('music_power_agent',\n",
-       "  Usage(model_name='gpt-4o-mini-2024-07-18', prompt_tokens=175, output_tokens=39)),\n",
-       " ('music_agent',\n",
-       "  Usage(model_name='claude-3-5-sonnet-20240620', prompt_tokens=3347, output_tokens=424)),\n",
+       "[('music_agent',\n",
+       "  Usage(model_name='claude-3-5-sonnet-20240620', prompt_tokens=3547, output_tokens=472)),\n",
        " ('lights_agent',\n",
-       "  Usage(model_name='gemini-2.0-flash-exp', prompt_tokens=466, output_tokens=14)),\n",
+       "  Usage(model_name='gemini-2.0-flash-exp', prompt_tokens=470, output_tokens=14)),\n",
+       " ('music_power_agent',\n",
+       "  Usage(model_name='gpt-4o-mini-2024-07-18', prompt_tokens=283, output_tokens=60)),\n",
        " ('disco_ball_agent',\n",
-       "  Usage(model_name='gpt-4o-2024-11-20', prompt_tokens=801, output_tokens=53)),\n",
+       "  Usage(model_name='gpt-4o-2024-11-20', prompt_tokens=786, output_tokens=47)),\n",
+       " ('music_control_agent',\n",
+       "  Usage(model_name='gemini-2.0-flash-exp', prompt_tokens=1184, output_tokens=148)),\n",
        " ('root',\n",
-       "  Usage(model_name='gpt-4o-2024-11-20', prompt_tokens=2599, output_tokens=354))]"
+       "  Usage(model_name='gpt-4o-2024-11-20', prompt_tokens=2618, output_tokens=363))]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -799,14 +893,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}\n"
+      "{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}\n"
      ]
     }
    ],
@@ -823,18 +917,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'disco_ball': {'power': True, 'spinning': True},\n",
-       " 'music': {'genre': <MusicGenre.pop: 'pop'>, 'bpm': 120, 'volume': 0.5},\n",
+       " 'music': {'genre': <MusicGenre.pop: 'pop'>, 'bpm': 120, 'volume': 0.8},\n",
        " 'lights': {'brightness': 0.8}}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -848,7 +942,108 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Conversation memory stores the conversation history in the top-level orchestrator agent."
+    "Top-level orchestrator and each subagent has own conversation memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nTurn this place into a party mood.\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - music_power_agent\\n    - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - music_control_agent\\n    - change_music: Change the music genre and BPM.\\n    - adjust_volume: Adjust the volume of the music.\\n    - change_bpm: Change the BPM of the music.\\n')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='### Plan to Turn the Place into a Party Mood:\\n\\n1. **Lights Setup**:\\n   - Use `lights_agent` to turn the lights on (`turn_light_on`).\\n   - Adjust the brightness of the lights to a party-appropriate level using `adjust_lights`.\\n\\n2. **Disco Ball Activation**:\\n   - Use `disco_ball_agent` to power the spinning disco ball (`power_disco_ball`).\\n\\n3. **Music Setup**:\\n   - Use `music_agent.music_power_agent` to start the music (`start_music`).\\n   - If needed, use `music_agent.music_control_agent` to:\\n     - Change the music genre and BPM to a party-friendly style (`change_music`).\\n     - Adjust the volume to an energetic level (`adjust_volume`).\\n\\n4. **Final Adjustments**:\\n   - Ensure all elements (lights, disco ball, and music) are synchronized for a cohesive party atmosphere.\\n\\nWould you like me to execute this plan?')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Put the plan into action.')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-appropriate level (e.g., 0.8).\"}', call_id='call_KKB8c9ih5rZR07oxUxVkg3St'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Power the disco ball and ensure it is spinning.\"}', call_id='call_4at0Okh6BKsO2q84meYfQo6M'), ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Start the music and ensure it is set to a party-friendly genre, BPM, and volume.\"}', call_id='call_BZkNx5HTA35RJosmA8pZ5AKl')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"brightness\": 0.8}', error=None, call_id='call_KKB8c9ih5rZR07oxUxVkg3St', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-appropriate level (e.g., 0.8).\"}', name='route_lights_agent'), ToolUsePrompt(output='{\"power\": true, \"spinning\": true}', error=None, call_id='call_4at0Okh6BKsO2q84meYfQo6M', args='{\"instruction\": \"Power the disco ball and ensure it is spinning.\"}', name='route_disco_ball_agent'), ToolUsePrompt(output='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', error=None, call_id='call_BZkNx5HTA35RJosmA8pZ5AKl', args='{\"instruction\": \"Start the music and ensure it is set to a party-friendly genre, BPM, and volume.\"}', name='route_music_agent')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.8},\"lights\":{\"brightness\":0.8}}', call_id='call_gDjp1862fyoBjhnoUh2Jhj5a')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}', error=None, call_id='call_gDjp1862fyoBjhnoUh2Jhj5a', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.8},\"lights\":{\"brightness\":0.8}}', name='final_answer')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None)]"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orchestrator.load_history()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Conversation memory of subagent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Agent(name=music_agent)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orchestrator.subagents[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Start the music and ensure it is set to a party-friendly genre, BPM, and volume.')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text=\"Certainly! I'll start the music for you and make sure it's set to a party-friendly configuration. To do this, I'll use the music power agent to start the music. The agent will randomly select a genre, BPM, and volume, but I'll instruct it to focus on party-friendly settings.\"), ToolCallResponse(name='route_music_power_agent', args='{\"instruction\": \"Start the music with settings suitable for a party. Choose a genre that\\'s typically popular for parties (like pop, hip-hop, or rock), set the BPM to an energetic level (around 120-140 BPM), and set the volume to a moderately high level (around 0.7-0.8) to create a lively atmosphere without being too loud.\"}', call_id='toolu_0197rYxcv6RX9sSpBfA5rC4D')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output=\"The music has started! It's set to a jazz genre with a BPM of 120 and a volume of approximately 0.89. While jazz isn't the typical party genre, it can still create a lively atmosphere. Enjoy the tunes!\", error=None, call_id='toolu_0197rYxcv6RX9sSpBfA5rC4D', args='{\"instruction\": \"Start the music with settings suitable for a party. Choose a genre that\\'s typically popular for parties (like pop, hip-hop, or rock), set the BPM to an energetic level (around 120-140 BPM), and set the volume to a moderately high level (around 0.7-0.8) to create a lively atmosphere without being too loud.\"}', name='route_music_power_agent')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='Great! The music has started, but it seems the random selection has given us a slightly unexpected result for a party. Let me adjust it to make it more party-friendly:'), ToolCallResponse(name='route_music_control_agent', args='{\"instruction\": \"Change the music to a more party-friendly genre like pop or hip-hop. Keep the BPM at 120 as it\\'s good for dancing. Slightly lower the volume to 0.8 to ensure comfortable conversation is still possible.\"}', call_id='toolu_01J7GDwReRuV1VCaxpiRr7cz')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output=\"OK, I've changed the music to pop with a BPM of 120 and adjusted the volume to 0.8.\", error=None, call_id='toolu_01J7GDwReRuV1VCaxpiRr7cz', args='{\"instruction\": \"Change the music to a more party-friendly genre like pop or hip-hop. Keep the BPM at 120 as it\\'s good for dancing. Slightly lower the volume to 0.8 to ensure comfortable conversation is still possible.\"}', name='route_music_control_agent')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text=\"Excellent! I've made the adjustments to create a more party-friendly atmosphere. Here's a summary of the current music settings:\"), ToolCallResponse(name='final_answer', args='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', call_id='toolu_01PCG6EtqCBfsQEorDet3CJk')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', error=None, call_id='toolu_01PCG6EtqCBfsQEorDet3CJk', args='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', name='final_answer')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None)]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orchestrator.subagents[2].load_history()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Agent(name=music_power_agent)"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orchestrator.subagents[2].subagents[0]"
    ]
   },
   {
@@ -859,14 +1054,10 @@
     {
      "data": {
       "text/plain": [
-       "[Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nTurn this place into a party mood.\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - music_power_agent\\n    - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - music_control_agent\\n    - change_music: Change the music genre and BPM.\\n    - adjust_volume: Adjust the volume of the music.\\n    - change_bpm: Change the BPM of the music.\\n')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[TextResponse(text='### Plan to Turn the Place into a Party Mood:\\n\\n1. **Lights Setup**:\\n   - Use `lights_agent` to turn the lights on.\\n   - Adjust the brightness of the lights to create a vibrant or dimmed party atmosphere using `adjust_lights`.\\n\\n2. **Disco Ball Activation**:\\n   - Use `disco_ball_agent` to power the spinning disco ball for a fun and dynamic visual effect.\\n\\n3. **Music Setup**:\\n   - Use `music_agent.music_power_agent` to start the music.\\n   - If needed, use `music_agent.music_control_agent` to:\\n     - Change the music genre and BPM to match the party vibe.\\n     - Adjust the volume to an appropriate level for the party.\\n\\n4. **Final Adjustments**:\\n   - Fine-tune the lights, disco ball, and music settings as needed to ensure the perfect party mood.\\n\\nWould you like me to execute this plan?')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
-       " Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Put the plan into action.')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-friendly level, such as 0.8.\"}', call_id='call_KZZDW9yVR21nhAJaVW8Ft2il'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Power the disco ball and make it spin for a party atmosphere.\"}', call_id='call_vN5lDDDtkopxPKH9qtFuRKUQ'), ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Start the music with a random genre, BPM, and volume to initiate the party mood.\"}', call_id='call_rm1IY9aZxQAIQlaPuXey0V3i')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
-       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"brightness\": 0.8}', error=None, call_id='call_KZZDW9yVR21nhAJaVW8Ft2il', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-friendly level, such as 0.8.\"}', name='route_lights_agent'), ToolUsePrompt(output='{\"power\": true, \"spinning\": true}', error=None, call_id='call_vN5lDDDtkopxPKH9qtFuRKUQ', args='{\"instruction\": \"Power the disco ball and make it spin for a party atmosphere.\"}', name='route_disco_ball_agent'), ToolUsePrompt(output='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}', error=None, call_id='call_rm1IY9aZxQAIQlaPuXey0V3i', args='{\"instruction\": \"Start the music with a random genre, BPM, and volume to initiate the party mood.\"}', name='route_music_agent')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.5},\"lights\":{\"brightness\":0.8}}', call_id='call_UM8CW6rlAlYR7GdZiGWl57Iw')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
-       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}', error=None, call_id='call_UM8CW6rlAlYR7GdZiGWl57Iw', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.5},\"lights\":{\"brightness\":0.8}}', name='final_answer')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None)]"
+       "[Prompt(type='Prompt', role='user', contents=[TextPrompt(text=\"Start the music with settings suitable for a party. Choose a genre that's typically popular for parties (like pop, hip-hop, or rock), set the BPM to an energetic level (around 120-140 BPM), and set the volume to a moderately high level (around 0.7-0.8) to create a lively atmosphere without being too loud.\")], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='start_music', args='{}', call_id='call_fbXGUmSJV4F4QWBhtHdAgmcg')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_power_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='Starting music! Genre: jazz, BPM: 120, Volume: 0.8883200024023981', error=None, call_id='call_fbXGUmSJV4F4QWBhtHdAgmcg', args='{}', name='start_music')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text=\"The music has started! It's set to a jazz genre with a BPM of 120 and a volume of approximately 0.89. While jazz isn't the typical party genre, it can still create a lively atmosphere. Enjoy the tunes!\")], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_power_agent', is_last_chunk=None, prompt=None)]"
       ]
      },
      "execution_count": 24,
@@ -875,7 +1066,7 @@
     }
    ],
    "source": [
-    "orchestrator.load_history()"
+    "orchestrator.subagents[2].subagents[0].load_history()"
    ]
   },
   {
@@ -894,55 +1085,58 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m[2025-01-02 20:25:54]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nPrefer to a jazz music with a calm tempo. Please change the music to jazz and stop the disco ball.\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - music_power_agent\\n    - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - music_control_agent\\n    - change_music: Change the music genre and BPM.\\n    - adjust_volume: Adjust the volume of the music.\\n    - change_bpm: Change the BPM of the music.\\n')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:54]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:55]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='### Plan to Adjust the Mood:\\n\\n1. **Music Adjustment**:\\n   - Use `music_agent.music_control_agent` to change the music genre to jazz and set a calm tempo (lower BPM).\\n\\n2. **Disco Ball Deactivation**:\\n   - Use `disco_ball_agent` to stop the disco ball power and spinning.\\n\\nWould you like me to execute this plan?')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:55]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:55]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:56]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Change the music to jazz with a calm tempo, setting the BPM to 80.\"}', call_id='call_IdRLN2QX1wkxcdFbB1Su1JHU'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Stop the disco ball power and spinning.\"}', call_id='call_yCzcrfMHh9rvbNY5dByYfeIR')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:56]\u001b[0m \u001b[1mINFO | Running tool: route_music_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:56]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Change the music to jazz with a calm tempo, setting the BPM to 80.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:56]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:58]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"Certainly! I'll adjust the music settings to jazz with a calmer tempo as you requested. Let me make those changes for you.\"), ToolCallResponse(name='route_music_control_agent', args='{\"instruction\": \"Change the music genre to jazz, set the BPM to 80 for a calm tempo, and keep the current volume.\"}', call_id='toolu_01RMAnkx8pqFASagFwu7M6PC')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:58]\u001b[0m \u001b[1mINFO | Running tool: route_music_control_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:58]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nChange the music genre to jazz, set the BPM to 80 for a calm tempo, and keep the current volume.\\n\\nCapabilities:\\n- change_music: Change the music genre and BPM.\\n- adjust_volume: Adjust the volume of the music.\\n- change_bpm: Change the BPM of the music.\\n')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:25:58]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='### Plan to Adjust Music:\\n\\n1. **Change Music Genre and BPM:**\\n   - Use `change_music` to set the music genre to \"jazz\" and the BPM to 80.\\n2. **Maintain Current Volume:**\\n   - No action needed for volume as the requirement is to keep the current volume.\\n\\nWould you like me to execute this plan?')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:00]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:01]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='change_music', args='{\"bpm\": 80, \"genre\": \"jazz\"}', call_id='d2zXPAPSEYHQQXCEwxQlSfV0')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:01]\u001b[0m \u001b[1mINFO | Running tool: change_music\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:01]\u001b[0m \u001b[1mINFO | Tool: change_music successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:01]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Changing music to jazz with BPM 80', error=None, call_id='d2zXPAPSEYHQQXCEwxQlSfV0', args='{\"bpm\": 80, \"genre\": \"jazz\"}', name='change_music')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:01]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:02]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='The music genre has been changed to jazz and the BPM has been set to 80. The volume remains unchanged.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:02]\u001b[0m \u001b[1mINFO | Tool: route_music_control_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:02]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='The music genre has been changed to jazz and the BPM has been set to 80. The volume remains unchanged.', error=None, call_id='toolu_01RMAnkx8pqFASagFwu7M6PC', args='{\"instruction\": \"Change the music genre to jazz, set the BPM to 80 for a calm tempo, and keep the current volume.\"}', name='route_music_control_agent')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:02]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:06]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Great! The music has been adjusted according to your preferences. Let me summarize the changes and provide you with the final answer:'), ToolCallResponse(name='final_answer', args='{\"genre\": \"jazz\", \"bpm\": 80, \"volume\": 0.5}', call_id='toolu_01SZseGAP3q613NiR9EFuEAz')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:06]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:06]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:06]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"genre\": \"jazz\", \"bpm\": 80, \"volume\": 0.5}')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:06]\u001b[0m \u001b[1mINFO | Tool: route_music_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:06]\u001b[0m \u001b[1mINFO | Running tool: route_disco_ball_agent\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:06]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Stop the disco ball power and spinning.')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:06]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:07]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='stop_disco_ball', args='{}', call_id='call_fKRbNPrDjaV44e3oTwp5110v')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:07]\u001b[0m \u001b[1mINFO | Running tool: stop_disco_ball\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:07]\u001b[0m \u001b[1mINFO | Tool: stop_disco_ball successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:07]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Stopping disco ball! Powered off and stopped spinning.', error=None, call_id='call_fKRbNPrDjaV44e3oTwp5110v', args='{}', name='stop_disco_ball')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:07]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:08]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"power\":false,\"spinning\":false}', call_id='call_ewrB8n8U4XMGdeOifAFLPXc8')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:08]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:08]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:08]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"power\": false, \"spinning\": false}')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:08]\u001b[0m \u001b[1mINFO | Tool: route_disco_ball_agent successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:08]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='{\"genre\": \"jazz\", \"bpm\": 80, \"volume\": 0.5}', error=None, call_id='call_IdRLN2QX1wkxcdFbB1Su1JHU', args='{\"instruction\": \"Change the music to jazz with a calm tempo, setting the BPM to 80.\"}', name='route_music_agent'), ToolUsePrompt(output='{\"power\": false, \"spinning\": false}', error=None, call_id='call_yCzcrfMHh9rvbNY5dByYfeIR', args='{\"instruction\": \"Stop the disco ball power and spinning.\"}', name='route_disco_ball_agent')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:08]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:09]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":false,\"spinning\":false},\"music\":{\"genre\":\"jazz\",\"bpm\":80,\"volume\":0.5},\"lights\":{\"brightness\":0.8}}', call_id='call_y6gSFYMeiPhOcAAQSKbftkYI')]\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:09]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:09]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
-      "\u001b[32m[2025-01-02 20:26:09]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"disco_ball\": {\"power\": false, \"spinning\": false}, \"music\": {\"genre\": \"jazz\", \"bpm\": 80, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}')]\u001b[0m\n"
+      "\u001b[32m[2025-01-05 21:51:00]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nPrefer to a jazz music with a calm tempo. Please change the music to jazz and stop the disco ball.\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - music_power_agent\\n    - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - music_control_agent\\n    - change_music: Change the music genre and BPM.\\n    - adjust_volume: Adjust the volume of the music.\\n    - change_bpm: Change the BPM of the music.\\n')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:00]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:02]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='### Plan to Adjust the Atmosphere:\\n\\n1. **Music Adjustment**:\\n   - Use `music_agent.music_control_agent` to change the music genre to jazz and set a calm tempo (low BPM).\\n\\n2. **Disco Ball Deactivation**:\\n   - Use `disco_ball_agent` to stop the disco ball power and spinning (`stop_disco_ball`).\\n\\nWould you like me to execute this plan?')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:02]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:02]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:03]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Change the music to jazz with a calm tempo (e.g., BPM around 70).\"}', call_id='call_3PLBAr3MX5L3F6vbtbcrTH4f'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Stop the disco ball power and spinning.\"}', call_id='call_A3Np0l62nuV9d14B9lHPVF8T')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:03]\u001b[0m \u001b[1mINFO | Running tool: route_music_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:03]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Change the music to jazz with a calm tempo (e.g., BPM around 70).')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:03]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:06]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"Certainly! I'll change the music to jazz with a calmer tempo as you requested. I'll use the music control agent to make these adjustments.\"), ToolCallResponse(name='route_music_control_agent', args='{\"instruction\": \"Change the music genre to jazz and set the BPM to around 70 for a calm tempo. Keep the current volume setting.\"}', call_id='toolu_01Uaeg3JaWY1zSA37Bw2NRRZ')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:06]\u001b[0m \u001b[1mINFO | Running tool: route_music_control_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:06]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nChange the music genre to jazz and set the BPM to around 70 for a calm tempo. Keep the current volume setting.\\n\\nCapabilities:\\n- change_music: Change the music genre and BPM.\\n- adjust_volume: Adjust the volume of the music.\\n- change_bpm: Change the BPM of the music.\\n')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:06]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:07]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Okay, here\\'s the plan:\\n\\n1. **Change Genre and BPM:** Use the `change_music` tool to switch the music genre to \"jazz\" and set the BPM to 70. Since the requirement is \"around 70\", I\\'ll use exactly 70.\\n2. **No Volume Adjustment:** The requirement specifies to keep the current volume, so I will not use the `adjust_volume` tool.\\n\\nThis plan directly addresses the requirements efficiently.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:07]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Put the plan into action.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:07]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:08]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='change_music', args='{\"bpm\": 70, \"genre\": \"jazz\"}', call_id='1YoHEHhdcwukc6DVE2OFhdsj')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:08]\u001b[0m \u001b[1mINFO | Running tool: change_music\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:08]\u001b[0m \u001b[1mINFO | Tool: change_music successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:08]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Changing music to jazz with BPM 70', error=None, call_id='1YoHEHhdcwukc6DVE2OFhdsj', args='{\"bpm\": 70, \"genre\": \"jazz\"}', name='change_music')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:08]\u001b[0m \u001b[1mINFO | music_control_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:09]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text=\"OK, I've changed the music to jazz with a BPM of 70, keeping the current volume.\")]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:09]\u001b[0m \u001b[1mINFO | Tool: route_music_control_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:09]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output=\"OK, I've changed the music to jazz with a BPM of 70, keeping the current volume.\", error=None, call_id='toolu_01Uaeg3JaWY1zSA37Bw2NRRZ', args='{\"instruction\": \"Change the music genre to jazz and set the BPM to around 70 for a calm tempo. Keep the current volume setting.\"}', name='route_music_control_agent')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:09]\u001b[0m \u001b[1mINFO | music_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='Great! The music has been changed according to your request. Let me summarize the new settings for you:'), ToolCallResponse(name='final_answer', args='{\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}', call_id='toolu_015yp6DAuvhpTxy6QiHXK4nb')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[1mINFO | Tool: route_music_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[1mINFO | Running tool: route_disco_ball_agent\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text='Stop the disco ball power and spinning.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='stop_disco_ball', args='{}', call_id='call_WnSoau8lKK5gY8QZiLK22gnp')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[1mINFO | Running tool: stop_disco_ball\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[1mINFO | Tool: stop_disco_ball successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='Stopping disco ball! Powered off and stopped spinning.', error=None, call_id='call_WnSoau8lKK5gY8QZiLK22gnp', args='{}', name='stop_disco_ball')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:11]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:12]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [TextResponse(text='The disco ball has been powered off and stopped spinning.')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:12]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [TextPrompt(text=\"Decide the next action based on the conversation. If you have all information for answering the user, run 'final_result' tool. If you need more information, invoke other tool to get necessary information. \")]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:12]\u001b[0m \u001b[1mINFO | disco_ball_agent: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:13]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"power\":false,\"spinning\":false}', call_id='call_CREsThE21r7OPWbMsS2MNYUi')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:13]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:13]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:13]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"power\": false, \"spinning\": false}')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:13]\u001b[0m \u001b[1mINFO | Tool: route_disco_ball_agent successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:13]\u001b[0m \u001b[34m\u001b[1mDEBUG | Prompt: [ToolUsePrompt(output='{\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}', error=None, call_id='call_3PLBAr3MX5L3F6vbtbcrTH4f', args='{\"instruction\": \"Change the music to jazz with a calm tempo (e.g., BPM around 70).\"}', name='route_music_agent'), ToolUsePrompt(output='{\"power\": false, \"spinning\": false}', error=None, call_id='call_A3Np0l62nuV9d14B9lHPVF8T', args='{\"instruction\": \"Stop the disco ball power and spinning.\"}', name='route_disco_ball_agent')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:13]\u001b[0m \u001b[1mINFO | root: Generating text\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:14]\u001b[0m \u001b[34m\u001b[1mDEBUG | Response: [ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":false,\"spinning\":false},\"music\":{\"genre\":\"jazz\",\"bpm\":70,\"volume\":0.8},\"lights\":{\"brightness\":0.8}}', call_id='call_Czh92tHp896ub6AH0RSfAcaR')]\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:14]\u001b[0m \u001b[1mINFO | Running tool: final_answer\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:14]\u001b[0m \u001b[1mINFO | Tool: final_answer successfully ran.\u001b[0m\n",
+      "\u001b[32m[2025-01-05 21:51:14]\u001b[0m \u001b[34m\u001b[1mDEBUG | Final result: [TextResponse(text='{\"disco_ball\": {\"power\": false, \"spinning\": false}, \"music\": {\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}')]\u001b[0m\n"
      ]
     }
    ],
@@ -960,14 +1154,14 @@
     {
      "data": {
       "text/plain": [
-       "[('music_control_agent',\n",
-       "  Usage(model_name='gemini-2.0-flash-exp', prompt_tokens=3452, output_tokens=111)),\n",
-       " ('disco_ball_agent',\n",
-       "  Usage(model_name='gpt-4o-2024-11-20', prompt_tokens=1958, output_tokens=33)),\n",
-       " ('music_agent',\n",
-       "  Usage(model_name='claude-3-5-sonnet-20240620', prompt_tokens=4082, output_tokens=229)),\n",
+       "[('disco_ball_agent',\n",
+       "  Usage(model_name='gpt-4o-2024-11-20', prompt_tokens=1292, output_tokens=46)),\n",
+       " ('music_control_agent',\n",
+       "  Usage(model_name='gemini-2.0-flash-exp', prompt_tokens=2211, output_tokens=133)),\n",
        " ('root',\n",
-       "  Usage(model_name='gpt-4o-2024-11-20', prompt_tokens=4599, output_tokens=200))]"
+       "  Usage(model_name='gpt-4o-2024-11-20', prompt_tokens=4645, output_tokens=208)),\n",
+       " ('music_agent',\n",
+       "  Usage(model_name='claude-3-5-sonnet-20240620', prompt_tokens=3339, output_tokens=230))]"
       ]
      },
      "execution_count": 26,
@@ -995,7 +1189,7 @@
      "data": {
       "text/plain": [
        "{'disco_ball': {'power': False, 'spinning': False},\n",
-       " 'music': {'genre': <MusicGenre.jazz: 'jazz'>, 'bpm': 80, 'volume': 0.5},\n",
+       " 'music': {'genre': <MusicGenre.jazz: 'jazz'>, 'bpm': 70, 'volume': 0.8},\n",
        " 'lights': {'brightness': 0.8}}"
       ]
      },
@@ -1010,6 +1204,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Conversation memory in top-level orchestrator."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 28,
    "metadata": {},
@@ -1018,21 +1219,21 @@
      "data": {
       "text/plain": [
        "[Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nTurn this place into a party mood.\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - music_power_agent\\n    - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - music_control_agent\\n    - change_music: Change the music genre and BPM.\\n    - adjust_volume: Adjust the volume of the music.\\n    - change_bpm: Change the BPM of the music.\\n')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[TextResponse(text='### Plan to Turn the Place into a Party Mood:\\n\\n1. **Lights Setup**:\\n   - Use `lights_agent` to turn the lights on.\\n   - Adjust the brightness of the lights to create a vibrant or dimmed party atmosphere using `adjust_lights`.\\n\\n2. **Disco Ball Activation**:\\n   - Use `disco_ball_agent` to power the spinning disco ball for a fun and dynamic visual effect.\\n\\n3. **Music Setup**:\\n   - Use `music_agent.music_power_agent` to start the music.\\n   - If needed, use `music_agent.music_control_agent` to:\\n     - Change the music genre and BPM to match the party vibe.\\n     - Adjust the volume to an appropriate level for the party.\\n\\n4. **Final Adjustments**:\\n   - Fine-tune the lights, disco ball, and music settings as needed to ensure the perfect party mood.\\n\\nWould you like me to execute this plan?')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='### Plan to Turn the Place into a Party Mood:\\n\\n1. **Lights Setup**:\\n   - Use `lights_agent` to turn the lights on (`turn_light_on`).\\n   - Adjust the brightness of the lights to a party-appropriate level using `adjust_lights`.\\n\\n2. **Disco Ball Activation**:\\n   - Use `disco_ball_agent` to power the spinning disco ball (`power_disco_ball`).\\n\\n3. **Music Setup**:\\n   - Use `music_agent.music_power_agent` to start the music (`start_music`).\\n   - If needed, use `music_agent.music_control_agent` to:\\n     - Change the music genre and BPM to a party-friendly style (`change_music`).\\n     - Adjust the volume to an energetic level (`adjust_volume`).\\n\\n4. **Final Adjustments**:\\n   - Ensure all elements (lights, disco ball, and music) are synchronized for a cohesive party atmosphere.\\n\\nWould you like me to execute this plan?')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
        " Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Put the plan into action.')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-friendly level, such as 0.8.\"}', call_id='call_KZZDW9yVR21nhAJaVW8Ft2il'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Power the disco ball and make it spin for a party atmosphere.\"}', call_id='call_vN5lDDDtkopxPKH9qtFuRKUQ'), ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Start the music with a random genre, BPM, and volume to initiate the party mood.\"}', call_id='call_rm1IY9aZxQAIQlaPuXey0V3i')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
-       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"brightness\": 0.8}', error=None, call_id='call_KZZDW9yVR21nhAJaVW8Ft2il', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-friendly level, such as 0.8.\"}', name='route_lights_agent'), ToolUsePrompt(output='{\"power\": true, \"spinning\": true}', error=None, call_id='call_vN5lDDDtkopxPKH9qtFuRKUQ', args='{\"instruction\": \"Power the disco ball and make it spin for a party atmosphere.\"}', name='route_disco_ball_agent'), ToolUsePrompt(output='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}', error=None, call_id='call_rm1IY9aZxQAIQlaPuXey0V3i', args='{\"instruction\": \"Start the music with a random genre, BPM, and volume to initiate the party mood.\"}', name='route_music_agent')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.5},\"lights\":{\"brightness\":0.8}}', call_id='call_UM8CW6rlAlYR7GdZiGWl57Iw')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
-       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}', error=None, call_id='call_UM8CW6rlAlYR7GdZiGWl57Iw', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.5},\"lights\":{\"brightness\":0.8}}', name='final_answer')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='route_lights_agent', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-appropriate level (e.g., 0.8).\"}', call_id='call_KKB8c9ih5rZR07oxUxVkg3St'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Power the disco ball and ensure it is spinning.\"}', call_id='call_4at0Okh6BKsO2q84meYfQo6M'), ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Start the music and ensure it is set to a party-friendly genre, BPM, and volume.\"}', call_id='call_BZkNx5HTA35RJosmA8pZ5AKl')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"brightness\": 0.8}', error=None, call_id='call_KKB8c9ih5rZR07oxUxVkg3St', args='{\"instruction\": \"Turn on the lights and adjust the brightness to a party-appropriate level (e.g., 0.8).\"}', name='route_lights_agent'), ToolUsePrompt(output='{\"power\": true, \"spinning\": true}', error=None, call_id='call_4at0Okh6BKsO2q84meYfQo6M', args='{\"instruction\": \"Power the disco ball and ensure it is spinning.\"}', name='route_disco_ball_agent'), ToolUsePrompt(output='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', error=None, call_id='call_BZkNx5HTA35RJosmA8pZ5AKl', args='{\"instruction\": \"Start the music and ensure it is set to a party-friendly genre, BPM, and volume.\"}', name='route_music_agent')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.8},\"lights\":{\"brightness\":0.8}}', call_id='call_gDjp1862fyoBjhnoUh2Jhj5a')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}', error=None, call_id='call_gDjp1862fyoBjhnoUh2Jhj5a', args='{\"disco_ball\":{\"power\":true,\"spinning\":true},\"music\":{\"genre\":\"pop\",\"bpm\":120,\"volume\":0.8},\"lights\":{\"brightness\":0.8}}', name='final_answer')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"disco_ball\": {\"power\": true, \"spinning\": true}, \"music\": {\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
        " Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Please make a concise plan to answer the following question/requirement, considering the conversation history.\\nYou can invoke the sub-agents or tools to answer the questions/requirements shown in the capabilities section.\\nAgent has no description while the tools have a description.\\n\\nQuestion/Requirement:\\nPrefer to a jazz music with a calm tempo. Please change the music to jazz and stop the disco ball.\\n\\nCapabilities:\\n- lights_agent\\n  - turn_light_on: Turn the lights on.\\n  - adjust_lights: Adjust the brightness of the lights.\\n- disco_ball_agent\\n  - power_disco_ball: Powers the spinning dissco ball.\\n  - stop_disco_ball: Stop the disco ball power and spinning.\\n- music_agent\\n  - music_power_agent\\n    - start_music: Turn on the music. The genre, BPM, and volume are randomly selected.\\n  - music_control_agent\\n    - change_music: Change the music genre and BPM.\\n    - adjust_volume: Adjust the volume of the music.\\n    - change_bpm: Change the BPM of the music.\\n')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[TextResponse(text='### Plan to Adjust the Mood:\\n\\n1. **Music Adjustment**:\\n   - Use `music_agent.music_control_agent` to change the music genre to jazz and set a calm tempo (lower BPM).\\n\\n2. **Disco Ball Deactivation**:\\n   - Use `disco_ball_agent` to stop the disco ball power and spinning.\\n\\nWould you like me to execute this plan?')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='### Plan to Adjust the Atmosphere:\\n\\n1. **Music Adjustment**:\\n   - Use `music_agent.music_control_agent` to change the music genre to jazz and set a calm tempo (low BPM).\\n\\n2. **Disco Ball Deactivation**:\\n   - Use `disco_ball_agent` to stop the disco ball power and spinning (`stop_disco_ball`).\\n\\nWould you like me to execute this plan?')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
        " Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Put the plan into action.')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Change the music to jazz with a calm tempo, setting the BPM to 80.\"}', call_id='call_IdRLN2QX1wkxcdFbB1Su1JHU'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Stop the disco ball power and spinning.\"}', call_id='call_yCzcrfMHh9rvbNY5dByYfeIR')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
-       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"genre\": \"jazz\", \"bpm\": 80, \"volume\": 0.5}', error=None, call_id='call_IdRLN2QX1wkxcdFbB1Su1JHU', args='{\"instruction\": \"Change the music to jazz with a calm tempo, setting the BPM to 80.\"}', name='route_music_agent'), ToolUsePrompt(output='{\"power\": false, \"spinning\": false}', error=None, call_id='call_yCzcrfMHh9rvbNY5dByYfeIR', args='{\"instruction\": \"Stop the disco ball power and spinning.\"}', name='route_disco_ball_agent')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":false,\"spinning\":false},\"music\":{\"genre\":\"jazz\",\"bpm\":80,\"volume\":0.5},\"lights\":{\"brightness\":0.8}}', call_id='call_y6gSFYMeiPhOcAAQSKbftkYI')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
-       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"disco_ball\": {\"power\": false, \"spinning\": false}, \"music\": {\"genre\": \"jazz\", \"bpm\": 80, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}', error=None, call_id='call_y6gSFYMeiPhOcAAQSKbftkYI', args='{\"disco_ball\":{\"power\":false,\"spinning\":false},\"music\":{\"genre\":\"jazz\",\"bpm\":80,\"volume\":0.5},\"lights\":{\"brightness\":0.8}}', name='final_answer')], name=None),\n",
-       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"disco_ball\": {\"power\": false, \"spinning\": false}, \"music\": {\"genre\": \"jazz\", \"bpm\": 80, \"volume\": 0.5}, \"lights\": {\"brightness\": 0.8}}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None)]"
+       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='route_music_agent', args='{\"instruction\": \"Change the music to jazz with a calm tempo (e.g., BPM around 70).\"}', call_id='call_3PLBAr3MX5L3F6vbtbcrTH4f'), ToolCallResponse(name='route_disco_ball_agent', args='{\"instruction\": \"Stop the disco ball power and spinning.\"}', call_id='call_A3Np0l62nuV9d14B9lHPVF8T')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}', error=None, call_id='call_3PLBAr3MX5L3F6vbtbcrTH4f', args='{\"instruction\": \"Change the music to jazz with a calm tempo (e.g., BPM around 70).\"}', name='route_music_agent'), ToolUsePrompt(output='{\"power\": false, \"spinning\": false}', error=None, call_id='call_A3Np0l62nuV9d14B9lHPVF8T', args='{\"instruction\": \"Stop the disco ball power and spinning.\"}', name='route_disco_ball_agent')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[ToolCallResponse(name='final_answer', args='{\"disco_ball\":{\"power\":false,\"spinning\":false},\"music\":{\"genre\":\"jazz\",\"bpm\":70,\"volume\":0.8},\"lights\":{\"brightness\":0.8}}', call_id='call_Czh92tHp896ub6AH0RSfAcaR')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"disco_ball\": {\"power\": false, \"spinning\": false}, \"music\": {\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}', error=None, call_id='call_Czh92tHp896ub6AH0RSfAcaR', args='{\"disco_ball\":{\"power\":false,\"spinning\":false},\"music\":{\"genre\":\"jazz\",\"bpm\":70,\"volume\":0.8},\"lights\":{\"brightness\":0.8}}', name='final_answer')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"disco_ball\": {\"power\": false, \"spinning\": false}, \"music\": {\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}, \"lights\": {\"brightness\": 0.8}}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name=None, is_last_chunk=None, prompt=None)]"
       ]
      },
      "execution_count": 28,
@@ -1045,18 +1246,64 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "Conversation memory of subagent."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Agent(name=music_agent)"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orchestrator.subagents[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Start the music and ensure it is set to a party-friendly genre, BPM, and volume.')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text=\"Certainly! I'll start the music for you and make sure it's set to a party-friendly configuration. To do this, I'll use the music power agent to start the music. The agent will randomly select a genre, BPM, and volume, but I'll instruct it to focus on party-friendly settings.\"), ToolCallResponse(name='route_music_power_agent', args='{\"instruction\": \"Start the music with settings suitable for a party. Choose a genre that\\'s typically popular for parties (like pop, hip-hop, or rock), set the BPM to an energetic level (around 120-140 BPM), and set the volume to a moderately high level (around 0.7-0.8) to create a lively atmosphere without being too loud.\"}', call_id='toolu_0197rYxcv6RX9sSpBfA5rC4D')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output=\"The music has started! It's set to a jazz genre with a BPM of 120 and a volume of approximately 0.89. While jazz isn't the typical party genre, it can still create a lively atmosphere. Enjoy the tunes!\", error=None, call_id='toolu_0197rYxcv6RX9sSpBfA5rC4D', args='{\"instruction\": \"Start the music with settings suitable for a party. Choose a genre that\\'s typically popular for parties (like pop, hip-hop, or rock), set the BPM to an energetic level (around 120-140 BPM), and set the volume to a moderately high level (around 0.7-0.8) to create a lively atmosphere without being too loud.\"}', name='route_music_power_agent')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='Great! The music has started, but it seems the random selection has given us a slightly unexpected result for a party. Let me adjust it to make it more party-friendly:'), ToolCallResponse(name='route_music_control_agent', args='{\"instruction\": \"Change the music to a more party-friendly genre like pop or hip-hop. Keep the BPM at 120 as it\\'s good for dancing. Slightly lower the volume to 0.8 to ensure comfortable conversation is still possible.\"}', call_id='toolu_01J7GDwReRuV1VCaxpiRr7cz')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output=\"OK, I've changed the music to pop with a BPM of 120 and adjusted the volume to 0.8.\", error=None, call_id='toolu_01J7GDwReRuV1VCaxpiRr7cz', args='{\"instruction\": \"Change the music to a more party-friendly genre like pop or hip-hop. Keep the BPM at 120 as it\\'s good for dancing. Slightly lower the volume to 0.8 to ensure comfortable conversation is still possible.\"}', name='route_music_control_agent')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text=\"Excellent! I've made the adjustments to create a more party-friendly atmosphere. Here's a summary of the current music settings:\"), ToolCallResponse(name='final_answer', args='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', call_id='toolu_01PCG6EtqCBfsQEorDet3CJk')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', error=None, call_id='toolu_01PCG6EtqCBfsQEorDet3CJk', args='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}', name='final_answer')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"genre\": \"pop\", \"bpm\": 120, \"volume\": 0.8}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[TextPrompt(text='Change the music to jazz with a calm tempo (e.g., BPM around 70).')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text=\"Certainly! I'll change the music to jazz with a calmer tempo as you requested. I'll use the music control agent to make these adjustments.\"), ToolCallResponse(name='route_music_control_agent', args='{\"instruction\": \"Change the music genre to jazz and set the BPM to around 70 for a calm tempo. Keep the current volume setting.\"}', call_id='toolu_01Uaeg3JaWY1zSA37Bw2NRRZ')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output=\"OK, I've changed the music to jazz with a BPM of 70, keeping the current volume.\", error=None, call_id='toolu_01Uaeg3JaWY1zSA37Bw2NRRZ', args='{\"instruction\": \"Change the music genre to jazz and set the BPM to around 70 for a calm tempo. Keep the current volume setting.\"}', name='route_music_control_agent')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='Great! The music has been changed according to your request. Let me summarize the new settings for you:'), ToolCallResponse(name='final_answer', args='{\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}', call_id='toolu_015yp6DAuvhpTxy6QiHXK4nb')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None),\n",
+       " Prompt(type='Prompt', role='user', contents=[ToolUsePrompt(output='{\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}', error=None, call_id='toolu_015yp6DAuvhpTxy6QiHXK4nb', args='{\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}', name='final_answer')], name=None),\n",
+       " Response(type='Response', role='assistant', contents=[TextResponse(text='{\"genre\": \"jazz\", \"bpm\": 70, \"volume\": 0.8}')], usage=Usage(model_name=None, prompt_tokens=0, output_tokens=0), raw=None, name='music_agent', is_last_chunk=None, prompt=None)]"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "orchestrator.subagents[2].load_history()"
+   ]
   },
   {
    "cell_type": "code",

--- a/src/langrila/core/agent.py
+++ b/src/langrila/core/agent.py
@@ -81,8 +81,9 @@ class Agent(Generic[ClientMessage, ClientSystemMessage, ClientMessageContent, Cl
         If you don't specify the conversation memory for subagent, InMemoryConversationMemory is internally
         used in default, which is not persisted automatically.
         Each subagent always need own conversation memory because the state within the multi-agent is kept or updated
-        based on the conversation history (and response schema if specified). Please be aware of using internal memory
-        even if you don't specify the conversation memory for the subagent.
+        based on the conversation history (and response schema if specified), and the scope of the state is limited
+        by the dependencies between agent. Please be aware of using internal memory even if you don't specify
+        the conversation memory for the subagent.
     agent_config : AgentConfig, optional
         The internal configuration of the agent, by default None.
     conversation_memory : BaseConversationMemory, optional

--- a/src/langrila/core/agent.py
+++ b/src/langrila/core/agent.py
@@ -1170,6 +1170,12 @@ class Agent(Generic[ClientMessage, ClientSystemMessage, ClientMessageContent, Cl
             )
         ]
 
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}(name={self._name})"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
 
 def _generate_dynamic_tool_as_agent(
     agent: Agent,  # type: ignore

--- a/src/langrila/core/agent.py
+++ b/src/langrila/core/agent.py
@@ -54,7 +54,14 @@ def format_validation_error_msg(e: ValidationError, tool_name: str) -> str:
 @dataclass(init=False)  # to apply pydantic TypeAdapter
 class Agent(Generic[ClientMessage, ClientSystemMessage, ClientMessageContent, ClientTool]):
     """
-    The Agent class is the main class to interact with the model and tools.
+    The Agent class is the main class to interact with the model and tools. Agent is responsible for
+    managing the conversation flow and the interaction with the model and tools looping through the process as needed.
+    The agent can be used to generate text, image, audio, and embed text.
+    The agent can also be used to stream text response from the model.
+
+    When running tools, the agent validates the input arguments based on the schema validator of the tool.
+    If an error occurs during the validation, the agent retries the tool call with the error message.
+    The agent retries the tool call until the maximum error retries count is reached.
 
     Parameters
     ----------
@@ -70,6 +77,12 @@ class Agent(Generic[ClientMessage, ClientSystemMessage, ClientMessageContent, Cl
         Subagents are treated as tools in the parent agent, which is prepared dynamically.
         Tool name is generated based on the subagent's variable name, e.g., route_{subagent_variable_name}.
         Please be careful for the conflict of the tool name in the global namespace.
+
+        If you don't specify the conversation memory for subagent, InMemoryConversationMemory is internally
+        used in default, which is not persisted automatically.
+        Each subagent always need own conversation memory because the state within the multi-agent is kept or updated
+        based on the conversation history and response schema if specified. Please be aware of using internal memory
+        even if you don't specify the conversation memory for the subagent.
     agent_config : AgentConfig, optional
         The internal configuration of the agent, by default None.
     conversation_memory : BaseConversationMemory, optional

--- a/src/langrila/core/agent.py
+++ b/src/langrila/core/agent.py
@@ -81,7 +81,7 @@ class Agent(Generic[ClientMessage, ClientSystemMessage, ClientMessageContent, Cl
         If you don't specify the conversation memory for subagent, InMemoryConversationMemory is internally
         used in default, which is not persisted automatically.
         Each subagent always need own conversation memory because the state within the multi-agent is kept or updated
-        based on the conversation history and response schema if specified. Please be aware of using internal memory
+        based on the conversation history (and response schema if specified). Please be aware of using internal memory
         even if you don't specify the conversation memory for the subagent.
     agent_config : AgentConfig, optional
         The internal configuration of the agent, by default None.


### PR DESCRIPTION
Force each subagent to use always own conversation memory because the state within the multi-agent is kept or updated based on the conversation history (and response schema if specified), and the scope of the state is limited by the dependencies between agent.